### PR TITLE
Use .real and .imag instead of .view(dtype=float) in case of slicing

### DIFF
--- a/waveform_base.py
+++ b/waveform_base.py
@@ -806,8 +806,8 @@ class WaveformBase(_object):
         W.data = np.empty((W.n_times,)+self.data.shape[1:], dtype=self.data.dtype)
         if self.data.dtype == np.dtype(complex):
             for i in range(W.n_data_sets):
-                W.data_2d[:, i] = (splev(W.t, splrep(self.t, self.data_2d.view(dtype=float)[:, 2*i], s=0), der=0)
-                                   + 1j*splev(W.t, splrep(self.t, self.data_2d.view(dtype=float)[:, 2*i+1], s=0), der=0))
+                W.data_2d[:, i] = (splev(W.t, splrep(self.t, self.data_2d[:, i].real, s=0), der=0)
+                                   + 1j*splev(W.t, splrep(self.t, self.data_2d[:, i].imag, s=0), der=0))
         elif self.data.dtype == np.dtype(float):
             for i in range(W.n_data_sets):
                 W.data_2d[:, i] = splev(W.t, splrep(self.t, self.data_2d[:, i], s=0), der=0)


### PR DESCRIPTION
Bugfix for #9. np.ndarray.view will raise a ValueError if data_2d is not C-contiguous, [as mentioned here](https://www.numpy.org/devdocs/reference/generated/numpy.ndarray.view.html). Using .real and .imag seems more robust. ~I don't know if this always does a deep copy, but I hope that python will detect if a shallow copy is possible~. EDIT: There is no deep copy, see [this example](https://github.com/moble/scri/issues/9#issuecomment-494516167)