### PR TITLE
WIP: Add function to compute momentum flux

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -86,7 +86,7 @@ DataNamesLaTeX = [r"\mathrm{unknown data type}", r"\psi_0", r"\psi_1", r"\psi_2"
 # Set up the WaveformModes object, by adding some methods
 from .waveform_modes import WaveformModes
 from .mode_calculations import (LdtVector, LVector, LLComparisonMatrix, LLMatrix,
-                                LLDominantEigenvector, angular_velocity, corotating_frame)
+                                LLDominantEigenvector, angular_velocity, corotating_frame, momentum_flux)
 WaveformModes.LdtVector = LdtVector
 WaveformModes.LVector = LVector
 WaveformModes.LLComparisonMatrix = LLComparisonMatrix
@@ -104,6 +104,7 @@ WaveformModes.to_coprecessing_frame = to_coprecessing_frame
 WaveformModes.to_corotating_frame = to_corotating_frame
 WaveformModes.to_inertial_frame = to_inertial_frame
 WaveformModes.align_decomposition_frame_to_modes = align_decomposition_frame_to_modes
+WaveformModes.momentum_flux = momentum_flux
 
 from .waveform_grid import WaveformGrid
 # from .waveform_in_detector import WaveformInDetector

--- a/mode_calculations.py
+++ b/mode_calculations.py
@@ -452,3 +452,51 @@ def corotating_frame(W, R0=quaternion.one, tolerance=1e-12, z_alignment_region=N
         return (frame * correction_rotor, omega)
     else:
         return frame * correction_rotor
+
+
+def momentum_flux(h):
+    """Compute momentum flux from waveform
+    
+    This implements Eqs. (6)-(8) from Gerosa, Hébert, Stein <https://arxiv.org/abs/1802.04276>
+    """
+    from .waveform_modes import WaveformModes
+    from . import h as htype
+    from . import hdot as hdottype
+    if not isinstance(h, WaveformModes):
+        raise ValueError("Momentum flux can only be calculated from a `WaveformModes` object; "
+                         +"this object is of type `{0}`.".format(type(h)))
+    if h.dataType == hdottype:
+        hdot = h
+    elif h.dataType == htype:
+        hdot = h.copy()
+        hdot.dataType = hdottype
+        hdot.data = h.data_dot
+    else:
+        raise ValueError("Input argument is expected to have data of type `h` or `hdot`; "
+                         +"this waveform data has type `{0}`".format(h.data_type_string))
+    pdot = np.zeros((hdot.n_times, 3), dtype=float)
+    ell, m = hdot.LM.T
+    alm = np.sqrt((ell-m)*(ell+m+1))/(ell*(ell+1))
+    blm = np.sqrt((ell-2)*(ell+2)*(ell+m)*(ell+m-1)/((2*ell-1)*(2*ell+1)))/(2*ell)
+    clm = 2*m/(ell*(ell+1))
+    dlm = np.sqrt((ell-2)*(ell+2)*(ell-m)*(ell+m)/((2*ell-1)*(2*ell+1)))/ell
+    for ell in range(2, hdot.ell_max+1):
+        i1 = hdot.index(ell, -ell)
+        i2 = hdot.index(ell, ell)
+        pdot[:, :2] += np.sum(alm[i1:i2] * hdot.data[:, i1:i2] * hdot.data[:, i1+1:i2+1].conjugate(), axis=1).view(float).reshape((-1, 2))
+        pdot[:, 2] += np.sum(clm[i1:i2+1] * hdot.data[:, i1:i2+1] * hdot.data[:, i1:i2+1].conjugate(), axis=1).real
+        if ell-1 >= hdot.ell_min:
+            i3 = hdot.index(ell-1, -(ell-1))
+            i4 = hdot.index(ell-1, ell-1)
+            pdot[:, :2] += np.sum(blm[i2:i1+2-1:-1] * hdot.data[:, i1:i2-1] * hdot.data[:, i3:i4+1].conjugate(), axis=1).view(float).reshape((-1, 2))
+            pdot[:, 2] += np.sum(dlm[i1+1:i2]  * hdot.data[:, i1+1:i2] * hdot.data[:, i3:i4+1].conjugate(), axis=1).real
+        if ell+1 <= hdot.ell_max:
+            i5 = hdot.index(ell+1, -ell+1)
+            i6 = hdot.index(ell+1, ell+1)
+            pdot[:, :2] -= np.sum(blm[i5:i6+1] * hdot.data[:, i1:i2+1] * hdot.data[:, i5:i6+1].conjugate(), axis=1).view(float).reshape((-1, 2))
+            i7 = hdot.index(ell+1, -ell)
+            i8 = hdot.index(ell+1, ell)
+            pdot[:, 2] += np.sum(dlm[i7:i8+1]  * hdot.data[:, i1:i2+1] * hdot.data[:, i7:i8+1].conjugate(), axis=1).real
+    pdot[:, :2] *= 2
+    pdot /= 16*np.pi
+    return pdot

--- a/tests/test_mode_calculations.py
+++ b/tests/test_mode_calculations.py
@@ -5,6 +5,7 @@ from __future__ import print_function, division, absolute_import
 
 import numpy as np
 import quaternion
+import spinsfast
 from numpy import *
 import pytest
 
@@ -126,3 +127,58 @@ def test_corotating_frame():
     w_rot.to_corotating_frame(R0=R0, tolerance=1e-12)
     assert w._allclose(w_rot, atol=1e-8)
     assert w_rot.frameType == Corotating
+
+
+def silly_momentum_flux(h):
+    """Compute momentum flux from waveform with a silly but simple method
+
+    This function evaluates the momentum-flux formula quite literally.  The formula is
+
+         dp       R**2  | dh |**2 ^
+    ---------- = ------ | -- |    n
+    dOmega  dt   16  pi | dt |
+
+    Here, p and nhat are vectors and R is the distance to the source.  The input h is differentiated
+    numerically to find modes of dh/dt, which are then used to construct the values of dh/dt on a
+    grid.  At each point of that grid, the value of |dh/dt|**2 nhat is computed, which is then
+    integrated over the sphere to arrive at dp/dt.  Note that this integration is accomplished by
+    way of a spherical-harmonic decomposition; the ell=m=0 mode is multiplied by 2*sqrt(pi) to
+    arrive at the result that would be achieved by integrating over the sphere.
+
+    """
+    import spinsfast
+    hdot = h.data_dot
+    zeros = np.zeros((hdot.shape[0], 4), dtype=hdot.dtype)
+    data = np.concatenate((zeros, hdot), axis=1)  # Pad with zeros for spinsfast
+    ell_min = 0
+    ell_max = 2*h.ell_max + 1  # Maximum ell value required for nhat*|hdot|^2
+    n_theta = 2*ell_max + 1
+    n_phi = n_theta
+    hdot_map = spinsfast.salm2map(data, h.spin_weight, h.ell_max, n_theta, n_phi)
+    hdot_mag_squared_map = hdot_map * hdot_map.conjugate()
+
+    theta = np.linspace(0.0, np.pi, num=n_theta, endpoint=True)
+    phi = np.linspace(0.0, 2*np.pi, num=n_phi, endpoint=False)
+    x = np.outer(np.sin(theta), np.cos(phi))
+    y = np.outer(np.sin(theta), np.sin(phi))
+    z = np.outer(np.cos(theta), np.ones_like(phi))
+
+    pdot = np.array([spinsfast.map2salm(hdot_mag_squared_map*n/(16*np.pi), 0, 0)[..., 0] * (2*np.sqrt(np.pi))
+                     for n in [x, y, z]]).T
+
+    return pdot
+
+
+def test_momentum_flux():
+    import numpy as np
+    import scri
+    directory = '/Users/boyle/Research/Data/SimulationAnnex/CatalogLinks/SXS:BBH:0030/Lev5/'
+    h = scri.SpEC.read_from_h5(directory+'rhOverM_Asymptotic_GeometricUnits_CoM.h5/Extrapolated_N2.dir')
+    pdot1 = silly_momentum_flux(h)
+    pdot2 = scri.momentum_flux(h)
+
+    # diff = np.linalg.norm(pdot1-pdot2, axis=1)
+    # ind = np.argmax(diff, axis=None)  # np.unravel_index(np.argmax(diff, axis=None), diff.shape)
+    # print('Max diff norm:', diff[ind], pdot1[ind], pdot2[ind], ind)
+
+    assert np.allclose(pdot1, pdot2, rtol=1e-13, atol=1e-13)


### PR DESCRIPTION
As suggested in https://github.com/sxs-collaboration/CatalogAnalysis/issues/23, I've started adding code to compute the linear momentum flux from a waveform.  At the moment, this includes a pretty rigorous test, except that the test references waveform files on my laptop; I need to create some good analytic waveforms to really test this properly.

I should also add a convenience function to integrate this over some period of time, and the very similar code needed to compute the energy and angular momenta.