### PR TITLE
General inner product functionality in mode_calculations

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -86,6 +86,7 @@ DataNamesLaTeX = [r"\mathrm{unknown data type}", r"\psi_0", r"\psi_1", r"\psi_2"
 # Set up the WaveformModes object, by adding some methods
 from .waveform_modes import WaveformModes
 from .mode_calculations import (LdtVector, LVector, LLComparisonMatrix, LLMatrix,
+                                inner_product,
                                 LLDominantEigenvector, angular_velocity, corotating_frame)
 WaveformModes.LdtVector = LdtVector
 WaveformModes.LVector = LVector

--- a/mode_calculations.py
+++ b/mode_calculations.py
@@ -558,11 +558,11 @@ def corotating_frame(
         return frame * correction_rotor
 
 
-def inner_product(t, abar, b, axis=-1, apply_conjugate=False):
+def inner_product(t, abar, b, axis=None, apply_conjugate=False):
     """Perform a time-domain complex inner product between two waveforms <a, b>.
 
-    This is implemented using Simpson's rule for numerical quadrature,
-    from scipy.integrate
+    This is implemented using spline interpolation, calling
+    quaternion.calculus.spline_definite_integral
 
     Parameters
     ----------
@@ -578,7 +578,8 @@ def inner_product(t, abar, b, axis=-1, apply_conjugate=False):
     axis : int, optional
         When abar and b are multidimensional, the inner product will
         be computed over this axis and the result will be one
-        dimension lower.  Default is -1.
+        dimension lower.  Default is None, will be inferred by
+        `spline_definite_integral`.
     apply_conjugate : bool, optional
         Whether or not to conjugate the abar argument before
         computing.  True means inner_product will perform the conjugation
@@ -591,11 +592,11 @@ def inner_product(t, abar, b, axis=-1, apply_conjugate=False):
         The integral along 'axis'
     """
 
-    from scipy.integrate import simps
+    from quaternion.calculus import spline_definite_integral as sdi
 
     if not apply_conjugate:
         integrand = abar*b
     else:
         integrand = np.conjugate(abar)*b
 
-    return simps(integrand, t, axis=axis)
+    return sdi(integrand, t, axis=axis)

--- a/mode_calculations.py
+++ b/mode_calculations.py
@@ -556,3 +556,46 @@ def corotating_frame(
         return (frame * correction_rotor, omega)
     else:
         return frame * correction_rotor
+
+
+def inner_product(t, abar, b, axis=-1, apply_conjugate=False):
+    """Perform a time-domain complex inner product between two waveforms <a, b>.
+
+    This is implemented using Simpson's rule for numerical quadrature,
+    from scipy.integrate
+
+    Parameters
+    ----------
+    t : array_like
+        Time samples for waveforms abar and b.
+    abar : array_like
+        The conjugate of the 'a' waveform in the inner product (or
+        simply a, if apply_conjugate=True is been passed).  Must have the
+        same shape as b.
+    b : array_like
+        The 'b' waveform in the inner product.  Must have the same
+        shape as a.
+    axis : int, optional
+        When abar and b are multidimensional, the inner product will
+        be computed over this axis and the result will be one
+        dimension lower.  Default is -1.
+    apply_conjugate : bool, optional
+        Whether or not to conjugate the abar argument before
+        computing.  True means inner_product will perform the conjugation
+        for you.  Default is False, meaning you have already
+        performed the conjugation.
+
+    Returns
+    -------
+    inner_product : ndarray
+        The integral along 'axis'
+    """
+
+    from scipy.integrate import simps
+
+    if not apply_conjugate:
+        integrand = abar*b
+    else:
+        integrand = np.conjugate(abar)*b
+
+    return simps(integrand, t, axis=axis)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ matplotlib
 h5py
 pytest
 numba
-numpy-quaternion>=2019.5.24.11.54.47
+numpy-quaternion>=2019.7.15.12.50.36
 spinsfast
 spherical_functions
 sxs

--- a/waveform_modes.py
+++ b/waveform_modes.py
@@ -317,7 +317,7 @@ class WaveformModes(WaveformBase):
 
 
     def inner_product(self, b,
-                      t0=None, t1=None,
+                      t1=None, t2=None,
                       allow_LM_differ=False, allow_times_differ=False):
         """Compute the all-angles inner product <self, b>.
 
@@ -330,8 +330,8 @@ class WaveformModes(WaveformBase):
         b : WaveformModes object
             The other set of modes to inner product with.
 
-        t0 : float, optional [default: None]
         t1 : float, optional [default: None]
+        t2 : float, optional [default: None]
             Lower and higher bounds of time integration
 
         allow_LM_differ : bool, optional [default: False]
@@ -350,7 +350,7 @@ class WaveformModes(WaveformBase):
             <self, b>
         """
 
-        from scipy.interpolate import InterpolatedUnivariateSpline as IUS
+        from quaternion.calculus import spline_definite_integral as sdi
 
         from .extrapolation import intersection
 
@@ -392,19 +392,15 @@ class WaveformModes(WaveformBase):
             A = A.interpolate(t_clip)
             B = B.interpolate(t_clip)
 
-        if (t0 is None):
-            t0 = times[0]
-
         if (t1 is None):
-            t1 = times[-1]
+            t1 = times[0]
+
+        if (t2 is None):
+            t2 = times[-1]
 
         integrand = np.sum(np.conj(A.data) * B.data, axis=1)
 
-        integrand_spline_r = IUS(times, integrand.real, bbox=[t0, t1])
-        integrand_spline_i = IUS(times, integrand.imag, bbox=[t0, t1])
-
-        return (integrand_spline_r.integral(t0, t1)
-                + 1.j * integrand_spline_i.integral(t0, t1) )
+        return sdi(integrand, times, t1=t1, t2=t2)
 
     # Involutions
     @property


### PR DESCRIPTION
This is baseline code which uses Simpson's rule from scipy.integrate.simps for quadrature. A better approach would be to use interpolation, but this will require using a wrapper function that @moble wrote for `quaternion`