### PR TITLE
Bugfix: _WaveformBase__num needs to be included for pickling

### DIFF
--- a/waveform_base.py
+++ b/waveform_base.py
@@ -754,8 +754,11 @@ class WaveformBase(_object):
         back to a quaternion array.
 
         """
-        old_num = state.pop('_WaveformBase__num')
+        new_num = self.__num
+        old_num = state.get('_WaveformBase__num')
         self.__dict__.update(state)
+        # Make sure to preserve auto-incremented num
+        self.__num = new_num
         self.frame = quaternion.as_quat_array(self.frame)
         self._append_history('copied, deepcopied, or unpickled as {0}'.format(self), 1)
         self._append_history('{0} = {1}'.format(self, '{0}'.format(self).replace(str(self.num), str(old_num))))


### PR DESCRIPTION
Pickling and unpickling a WaveformBase object doesn't work.  The
problem resides in the class variable `WaveformBase.__num`, which gets
name mangled to `_WaveformBase__num` because of python conventions.  The
current `__getstate__`/`__setstate__` pair try to avoid copying
`_WaveformBase__num` in order to preserve the auto-incremented counter
`__num`, which is automatically set in `__init__`. However, pickle does
something funny that I don't fully understand, so `_WaveformBase__num`
ends up not being a member unless it *is* copied. Minimal breaking
example below.

The fix is to let `__init__` auto-increment `__num`; then upon entering
`__setstate__`, store this value in a temp, update the `__dict__`, which
overwrites `__num`, but then revert `__num` to the temp.

Minimal breaking example which is fixed by this bugfix:

```python
import scri
import pickle
W = scri.WaveformModes()
W_str = pickle.dumps(W)
W2 = pickle.loads(W_str)
print('_WaveformBase__num' in W.__dict__.keys())
print('_WaveformBase__num' in W2.__dict__.keys())
```