### PR TITLE
Fix sqrt in extrapolation

### DIFF
--- a/mode_calculations.py
+++ b/mode_calculations.py
@@ -551,7 +551,7 @@ def corotating_frame(
             *np.mean(Vhat_corot, axis=0)
         ).normalized()
         # print(i1, i2, i1m, i1p, RoughDirection, Vhat[0], Vhat_corot[0], Vhat_corot_mean)
-        correction_rotor = np.sqrt(-quaternion.z * Vhat_corot_mean).inverse()
+        correction_rotor = (-quaternion.z * Vhat_corot_mean).sqrt().inverse()
     # R = squad(R, t, W.t)
     if return_omega:
         return (frame * correction_rotor, omega)


### PR DESCRIPTION
Extrapolation was still failing even with commit ae82f6e08bd951955ebbec4cfe4b66dfe9b20db0. The error is:
```
TypeError: ufunc 'sqrt' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
```