### PR TITLE
Exclude insignificant outer radii from Psi1 and Psi0 extrapolation

### DIFF
--- a/extrapolation.py
+++ b/extrapolation.py
@@ -1433,7 +1433,7 @@ def _Extrapolate(FiniteRadiusWaveforms, Radii, ExtrapolationOrders, Omegas=None,
     NExtrapolations = len(ExtrapolationOrders)
     SVDTol = 1.0e-12  # Same as Numerical Recipes default in fitsvd.h
     DataType = FiniteRadiusWaveforms[NFiniteRadii-1].dataType
-    ExcludeInsignificantRadii = True if ((DataType in [scri.psi1, scri.psi0]) and ErrorTol) else False
+    ExcludeInsignificantRadii = DataType in [scri.psi1, scri.psi0]) and bool(ErrorTol)
     if ExcludeInsignificantRadii:
         from spherical_functions import LM_index
         ell_min = FiniteRadiusWaveforms[NFiniteRadii - 1].ell_min

--- a/extrapolation.py
+++ b/extrapolation.py
@@ -1433,7 +1433,7 @@ def _Extrapolate(FiniteRadiusWaveforms, Radii, ExtrapolationOrders, Omegas=None,
     NExtrapolations = len(ExtrapolationOrders)
     SVDTol = 1.0e-12  # Same as Numerical Recipes default in fitsvd.h
     DataType = FiniteRadiusWaveforms[NFiniteRadii-1].dataType
-    ExcludeInsignificantRadii = DataType in [scri.psi1, scri.psi0]) and bool(ErrorTol)
+    ExcludeInsignificantRadii = DataType in [scri.psi1, scri.psi0] and bool(ErrorTol)
     if ExcludeInsignificantRadii:
         from spherical_functions import LM_index
         ell_min = FiniteRadiusWaveforms[NFiniteRadii - 1].ell_min

--- a/extrapolation.py
+++ b/extrapolation.py
@@ -1579,14 +1579,14 @@ def _Extrapolate(FiniteRadiusWaveforms, Radii, ExtrapolationOrders, Omegas=None,
             Im = data[:, i_t, :, 1]
 
             if ExcludeInsignificantRadii:
-                # Psi1 and Psi0 fall off as O(r^-4) and O(r^-5), which falls below a tolerance of significance
-                # within the region that wave extraction is performed. Extraction radii with a waveform amplitude
-                # below ErrorTol will not be used for extrapolation.
-                ErrorTol = 1e-9
+                # For the sake of avoiding a poorly conditioned polynomial fit, we need to set an absolute minimum for the
+                # possible number of radii that may be used. Occasionally where there is junk radiation the amplitude of
+                # the waveform may be spuriously small at a few timesteps, setting this minimum avoids excluding an
+                # unreasonable number of radii and then having polyfit return an error.
+                MinimumNRadii = NExtrapolations + 4
 
                 # Since we are in the corotating frame, we can be sure that the (2,2) mode is dominant. For the sake of
                 # consistency we will use the same radial weights for each mode at a given retarded time.
-                MinimumNRadii = NExtrapolations + 4
                 WaveformAmplitude = np.abs(Re[MinimumNRadii,LM_index(2,2,ell_min)] + 1j*Im[MinimumNRadii,LM_index(2,2,ell_min)])
 
                 # Radius at which the amplitude of the waveform is equal to error_tol.

--- a/extrapolation.py
+++ b/extrapolation.py
@@ -1583,18 +1583,18 @@ def _Extrapolate(FiniteRadiusWaveforms, Radii, ExtrapolationOrders, Omegas=None,
                 # possible number of radii that may be used. Occasionally where there is junk radiation the amplitude of
                 # the waveform may be spuriously small at a few timesteps, setting this minimum avoids excluding an
                 # unreasonable number of radii and then having polyfit return an error.
-                MinimumNRadii = NExtrapolations + 4
+                MinimumNRadii = max(ExtrapolationOrders) + 4
 
                 # Since we are in the corotating frame, we can be sure that the (2,2) mode is dominant. For the sake of
                 # consistency we will use the same radial weights for each mode at a given retarded time.
-                WaveformAmplitude = np.abs(Re[MinimumNRadii,LM_index(2,2,ell_min)] + 1j*Im[MinimumNRadii,LM_index(2,2,ell_min)])
+                WaveformAmplitude = np.linalg.norm(Re[MinimumNRadii] + 1j*Im[MinimumNRadii])
 
                 # Radius at which the amplitude of the waveform is equal to error_tol.
                 LargestSignificantRadius = (WaveformAmplitude/ErrorTol)**(1/(6-DataType))
 
                 # Use as many radii as possible that are smaller than LargestSignificantRadius.
                 RadiiOnTimeSlice = np.array(Radii)[:,i_t]
-                MinimumNRadii= max(len(RadiiOnTimeSlice[RadiiOnTimeSlice <= LargestSignificantRadius]), MinimumNRadii)
+                MinimumNRadii= max(sum(RadiiOnTimeSlice <= LargestSignificantRadius), MinimumNRadii)
 
                 # Remove the outer radii
                 OneOverRadii = OneOverRadii[:MinimumNRadii]


### PR DESCRIPTION
SpEC's extraction procedure has been optimized for Psi1 and Psi0 waveforms. This involves having the innermost extraction radius moved to a MUCH smaller radius (2 reduced GW wavelengths as determined by the initial data). The outermost extraction has not changed. 

Since Psi1 and Psi0 fall off as r^-4 and r^-5, the amplitude of even their dominant mode will fall beneath the error tolerance of SpEC within the extraction region. To optimize the extrapolation for these quantities, we find which outer radii on a given time slice will have a waveform value beneath a user-set tolerance. These outer radii will then be excluded from being used in extrapolation. 