### PR TITLE
Load h5 files into an ABD object

### DIFF
--- a/scri/SpEC/__init__.py
+++ b/scri/SpEC/__init__.py
@@ -5,4 +5,4 @@
 from .._version import __version__
 
 from .com_motion import com_motion, estimate_avg_com_motion, remove_avg_com_motion
-from .file_io import read_from_h5, write_to_h5
+from .file_io import read_from_h5, write_to_h5, create_abd_from_h5

--- a/scri/SpEC/file_io/__init__.py
+++ b/scri/SpEC/file_io/__init__.py
@@ -469,7 +469,8 @@ def create_abd_from_h5(file_format, convention='SpEC', **kwargs):
             )
 
     # Create an instance of AsymptoticBondiData
-    abd = AsymptoticBondiData(time=WM_ref.t, ell_max=WM_ref.ell_max, multiplication_truncator=max,)
+    is_dimensionless = False if convention == 'CCE' else True
+    abd = AsymptoticBondiData(time=WM_ref.t, ell_max=WM_ref.ell_max, multiplication_truncator=max, is_dimensionless=is_dimensionless)
 
     # Define factors to convert between input waveform convention and Moreschi-Boyle convention
     conversion_factor = {

--- a/scri/SpEC/file_io/__init__.py
+++ b/scri/SpEC/file_io/__init__.py
@@ -8,9 +8,11 @@ import ast
 import numpy as np
 import quaternion
 import spherical_functions as sf
-from ... import jit, WaveformModes, FrameNames, DataType, DataNames, UnknownDataType, h, hdot, psi4, psi3, psi2, psi1, psi0
+from ... import jit, WaveformModes, FrameNames, DataType, DataNames, UnknownDataType, h, hdot, psi4, psi3, psi2, psi1, psi0, Inertial
 from sxs.metadata import Metadata
 from . import corotating_paired_xor, rotating_paired_xor_multishuffle_bzip2
+
+from ...asymptotic_bondi_data import AsymptoticBondiData
 
 
 def translate_data_types_GWFrames_to_waveforms(d):
@@ -308,7 +310,7 @@ def read_from_h5(file_name, **kwargs):
 
 def write_to_h5(w, file_name, file_write_mode="w", attributes={}, use_NRAR_format=True):
     """
-    Output the Waveform to an HDF5 file. Default behavior uses the NRAR format. 
+    Output the Waveform to an HDF5 file. Default behavior uses the NRAR format.
 
     Note that the file_name is prepended with some descriptive information involving the data type and the frame type,
     such as 'rhOverM_Corotating_' or 'rMpsi4_Aligned_'.
@@ -387,3 +389,110 @@ def write_to_h5(w, file_name, file_write_mode="w", attributes={}, use_NRAR_forma
                 Data_m.attrs["m"] = m
     finally:  # Use `finally` to make sure this happens:
         f.close()
+
+
+def create_abd_from_h5(file_format, convention='SpEC', **kwargs):
+    """Returns an AsymptoticBondiData object with waveform data loaded from specified H5 files.
+
+    The AsymptoticBondiData class internally uses the Moreschi-Boyle conventions, see the following reference:
+      O. Moreschi, On angular momentum at future null infinity, DOI:10.1088/0264-9381/3/4/006
+    If necessary, the waveform data will be converted to the Moreschi-Boyle conventions when loaded.
+
+    Parameters
+    ----------
+    file_format : 'SXS', 'CCE', 'CPX', or 'RPXM'
+        The H5 files may be in the one of the following file formats:
+          * 'SXS'  - Dimensionless extrapolated waveform files found in the SXS Catalog, also known as NRAR format.
+          * 'CCE'  - Asymptotic waveforms output by SpECTRE CCE. These are not dimensionless.
+          * 'CPX'  - Dimensionless waveforms compressed using the corotating_paired_xor format.
+          * 'RPXM' - Dimensionless waveforms compressed using the rotating_paired_xor_multishuffle_bzip2 format.
+    convention : 'SpEC' or 'Moreschi-Boyle'
+        The data conventions of the waveform data that will be loaded. This defaults to 'SpEC' since this will be
+        most often used with 'SpEC' convention waveforms.
+
+
+    Keyword Parameters
+    ------------------
+    Psi4 : str, optional
+    Psi3 : str, optional
+    Psi2 : str, optional
+    Psi1 : str, optional
+    Psi0 : str, optional
+    h    : str, optional
+        Path to H5 file containing the data. At least ONE the above waveform quantities is required.
+
+
+    Returns
+    -------
+    abd: AsymptoticBondiData
+
+    """
+
+    # Use case insensitive parameters
+    file_format = file_format.lower()
+    convention = convention.lower()
+
+    # Load waveform data from H5 files into WaveformModes objects
+    WMs = {}
+    filenames = {}
+    for data_label in ["Psi4", "Psi3", "Psi2", "Psi1", "Psi0", "h"]:
+        if data_label in kwargs:
+            filenames[data_label] = kwargs.pop(data_label)
+            if file_format == "sxs":
+                WMs[data_label] = read_from_h5(filenames[data_label])
+            elif file_format == "cce":
+                WMs[data_label] = read_from_h5(
+                    filenames[data_label],
+                    dataType=DataNames.index(data_label),
+                    frameType=Inertial,
+                    r_is_scaled_out=True,
+                    m_is_scaled_out=False,
+                )
+            elif file_format == "cpx":
+                WMs[data_label] = corotating_paired_xor.load(filenames[data_label])
+                WMs[data_label].to_inertial_frame()
+            elif file_format == "rpxm":
+                WMs[data_label] = rotating_paired_xor_multishuffle_bzip2.load(filenames[data_label])[0]
+                WMs[data_label].to_inertial_frame()
+            else:
+                raise ValueError(f"File format '{file_format}' not recognized. Must be either SXS, CCE, or CPX.")
+
+    # Sanity check
+    if not WMs:
+        raise ValueError("No filenames have been provided. The data of at least one waveform quantity is required.")
+    WM_ref = WMs[list(WMs.keys())[0]]
+    for i in WMs:
+        if not (WM_ref.t == WMs[i].t).all():
+            raise ValueError(
+                f"All waveforms must share the same set of times. The data "
+                "for {list(WMs.keys())[i].data_type_string} has a different set of times."
+            )
+
+    # Create an instance of AsymptoticBondiData
+    abd = AsymptoticBondiData(time=WM_ref.t, ell_max=WM_ref.ell_max, multiplication_truncator=max,)
+
+    # Define factors to convert between input waveform convention and Moreschi-Boyle convention
+    conversion_factor = {
+        # "input convention" : [Ψ0, Ψ1, Ψ2, Ψ3, Ψ4, h]
+        "moreschi-boyle" : [1, 1, 1, 1, 1, 1],
+        "spec" : [2, -np.sqrt(2), 1, -1/np.sqrt(2), 0.5, 0.5],
+    }
+
+    # Load the WaveformModes data into the ABD object and convert to the Moreschi-Boyle convention.
+    if "Psi4" in WMs:
+        abd.psi4[:, sf.LM_index(WMs["Psi4"].ell_min, -WMs["Psi4"].ell_min, 0) :] = conversion_factor[convention][4] * WMs["Psi4"].data
+    if "Psi3" in WMs:
+        abd.psi3[:, sf.LM_index(WMs["Psi3"].ell_min, -WMs["Psi3"].ell_min, 0) :] = conversion_factor[convention][3] * WMs["Psi3"].data
+    if "Psi2" in WMs:
+        abd.psi2[:, sf.LM_index(WMs["Psi2"].ell_min, -WMs["Psi2"].ell_min, 0) :] = conversion_factor[convention][2] * WMs["Psi2"].data
+    if "Psi1" in WMs:
+        abd.psi1[:, sf.LM_index(WMs["Psi1"].ell_min, -WMs["Psi1"].ell_min, 0) :] = conversion_factor[convention][1] * WMs["Psi1"].data
+    if "Psi0" in WMs:
+        abd.psi0[:, sf.LM_index(WMs["Psi0"].ell_min, -WMs["Psi0"].ell_min, 0) :] = conversion_factor[convention][0] * WMs["Psi0"].data
+    # abd uses the Newman-Penrose scalar sigma instead of the strain h, so we have to take
+    # the complex conjugate.
+    if "h" in WMs:
+        abd.sigma[:, sf.LM_index(WMs["h"].ell_min, -WMs["h"].ell_min, 0) :] = conversion_factor[convention][5] * WMs["h"].data
+        abd.sigma = abd.sigma.bar
+
+    return abd

--- a/scri/asymptotic_bondi_data/__init__.py
+++ b/scri/asymptotic_bondi_data/__init__.py
@@ -1,7 +1,7 @@
 from math import sqrt, pi
 import numpy as np
 from spherical_functions import LM_total_size
-from .. import ModesTimeSeries
+from ..modes_time_series import ModesTimeSeries
 
 
 class AsymptoticBondiData:

--- a/scri/asymptotic_bondi_data/__init__.py
+++ b/scri/asymptotic_bondi_data/__init__.py
@@ -31,7 +31,7 @@ class AsymptoticBondiData:
 
     """
 
-    def __init__(self, time, ell_max, multiplication_truncator=sum):
+    def __init__(self, time, ell_max, multiplication_truncator=sum, is_dimensionless=False):
         """Create new storage for asymptotic Bondi data
 
         Parameters
@@ -48,6 +48,9 @@ class AsymptoticBondiData:
             also the most wasteful, and very likely to be overkill.  The user should probably always
             use `max`.  (Unfortunately, this must remain an opt-in choice, to ensure that the user
             is aware of the situation.)
+        is_dimensionless: bool [defaults to False]
+            If True, the Bondi data will be treated under BMS transformations as dimensionless quantities
+            with all factors of the mass being scaled out.
 
         """
         import functools
@@ -61,6 +64,7 @@ class AsymptoticBondiData:
             raise ValueError(f"Input `time` parameter must have dtype float; it has dtype {time.dtype}")
         ModesTS = functools.partial(ModesTimeSeries, ell_max=ell_max, multiplication_truncator=multiplication_truncator)
         shape = [6, time.size, LM_total_size(0, ell_max)]
+        self._is_dimensionless = is_dimensionless
         self._time = time.copy()
         self._raw_data = np.zeros(shape, dtype=complex)
         self._psi0 = ModesTS(self._raw_data[0], self._time, spin_weight=2)
@@ -98,6 +102,10 @@ class AsymptoticBondiData:
     @property
     def ell_max(self):
         return self._psi2.ell_max
+
+    @property
+    def is_dimensionless(self):
+        return self._is_dimensionless
 
     @property
     def sigma(self):

--- a/scri/asymptotic_bondi_data/transformations.py
+++ b/scri/asymptotic_bondi_data/transformations.py
@@ -382,6 +382,11 @@ def transform(self, **kwargs):
     fprime_temp *= one_over_k
     fprime_of_timenaught_directionprime[5] = fprime_temp
 
+    if self.is_dimensionless:
+        # Multiply by γ for each factor of the mass that is being used to set the Bondi data dimensionless.
+        # The gamma weights for each quantity are:              ψ0   ψ1   ψ2  ψ3  ψ4   σ
+        fprime_of_timenaught_directionprime *= (γ ** np.array([-3., -2., -1., 0., 1., -1.]))[:,np.newaxis,np.newaxis,np.newaxis]
+
     # Determine the new time slices.  The set timeprime is chosen so that on each slice of constant
     # u'_i, the average value of u=(u'/k)+α is precisely <u>=u'γ+<α>=u_i.  But then, we have to
     # narrow that set down, so that every grid point on all the u'_i' slices correspond to data in


### PR DESCRIPTION
[**DEPENDS ON PR #37** - The convention dictionary here assumes `constraints.py` is in Moreschi-Boyle conventions] 

This provides a convenient way to load H5 files into an ABD object. It can handle various file types and can be easily extendible for other waveform conventions as well. This is just one way to handle the issue of differing sign conventions so I'm open for other thoughts or discussion!