### PR TITLE
Fix broken tests in test_waveform_grid.py

### DIFF
--- a/tests/test_waveform_grid.py
+++ b/tests/test_waveform_grid.py
@@ -48,11 +48,16 @@ def test_space_translation():
             print("\tWorking on spin s =", s, ", ell =", ell)
             for m in range(-ell, ell + 1):
                 for space_translation in [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]:
+                    auxiliary_waveforms = {}
+                    for i in range(s+2):
+                        auxiliary_waveforms[f"psi{4-i}_modes"] = samples.single_mode_proportional_to_time(s=i-2)
+                        auxiliary_waveforms[f"psi{4-i}_modes"].data *= 0
                     w_m1 = samples.single_mode_proportional_to_time(s=s, ell=ell, m=m).transform(
-                        space_translation=space_translation
+                        space_translation=space_translation,
+                        **auxiliary_waveforms,
                     )
                     w_m2 = samples.single_mode_proportional_to_time_supertranslated(
-                        s=s, ell=ell, m=m, space_translation=space_translation
+                        s=s, ell=ell, m=m, space_translation=np.array(space_translation)
                     )
                     i1A = np.argmin(abs(w_m1.t - (w_m1.t[0] + 2 * np.linalg.norm(space_translation))))
                     i1B = np.argmin(abs(w_m1.t - (w_m1.t[-1] - 2 * np.linalg.norm(space_translation))))
@@ -109,8 +114,13 @@ def test_hyper_translation():
                     max_displacement = abs(
                         spinsfast.salm2map(supertranslation, 0, ell_max, 4 * ell_max + 1, 4 * ell_max + 1)
                     ).max()
+                    auxiliary_waveforms = {}
+                    for i in range(s+2):
+                        auxiliary_waveforms[f"psi{4-i}_modes"] = samples.single_mode_proportional_to_time(s=i-2)
+                        auxiliary_waveforms[f"psi{4-i}_modes"].data *= 0
                     w_m1 = samples.single_mode_proportional_to_time(s=s, ell=ell, m=m).transform(
-                        supertranslation=supertranslation
+                        supertranslation=supertranslation,
+                        **auxiliary_waveforms,
                     )
                     w_m2 = samples.single_mode_proportional_to_time_supertranslated(
                         s=s, ell=ell, m=m, supertranslation=supertranslation

--- a/tests/test_waveform_grid.py
+++ b/tests/test_waveform_grid.py
@@ -49,12 +49,11 @@ def test_space_translation():
             for m in range(-ell, ell + 1):
                 for space_translation in [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]:
                     auxiliary_waveforms = {}
-                    for i in range(s+2):
-                        auxiliary_waveforms[f"psi{4-i}_modes"] = samples.single_mode_proportional_to_time(s=i-2)
+                    for i in range(s + 2):
+                        auxiliary_waveforms[f"psi{4-i}_modes"] = samples.single_mode_proportional_to_time(s=i - 2)
                         auxiliary_waveforms[f"psi{4-i}_modes"].data *= 0
                     w_m1 = samples.single_mode_proportional_to_time(s=s, ell=ell, m=m).transform(
-                        space_translation=space_translation,
-                        **auxiliary_waveforms,
+                        space_translation=space_translation, **auxiliary_waveforms,
                     )
                     w_m2 = samples.single_mode_proportional_to_time_supertranslated(
                         s=s, ell=ell, m=m, space_translation=np.array(space_translation)
@@ -115,12 +114,11 @@ def test_hyper_translation():
                         spinsfast.salm2map(supertranslation, 0, ell_max, 4 * ell_max + 1, 4 * ell_max + 1)
                     ).max()
                     auxiliary_waveforms = {}
-                    for i in range(s+2):
-                        auxiliary_waveforms[f"psi{4-i}_modes"] = samples.single_mode_proportional_to_time(s=i-2)
+                    for i in range(s + 2):
+                        auxiliary_waveforms[f"psi{4-i}_modes"] = samples.single_mode_proportional_to_time(s=i - 2)
                         auxiliary_waveforms[f"psi{4-i}_modes"].data *= 0
                     w_m1 = samples.single_mode_proportional_to_time(s=s, ell=ell, m=m).transform(
-                        supertranslation=supertranslation,
-                        **auxiliary_waveforms,
+                        supertranslation=supertranslation, **auxiliary_waveforms,
                     )
                     w_m2 = samples.single_mode_proportional_to_time_supertranslated(
                         s=s, ell=ell, m=m, supertranslation=supertranslation


### PR DESCRIPTION
This fixes Issue #44.

Instead of overcomplicating the test, we'll take it that `scri.sample_waveforms.single_mode_proportional_to_time_supertranslated()` operates with the assumption that all other Weyl scalars are zero. However, we still need to pass in empty `scri.WaveformModes` objects into the transformation function of `scri.sample_waveforms.single_mode_proportional_to_time()`.