### PR TITLE
Treat the Christodoulou mass as Lorentz invariant

### DIFF
--- a/scri/waveform_grid.py
+++ b/scri/waveform_grid.py
@@ -557,7 +557,7 @@ class WaveformGrid(WaveformBase):
                 )
                 warnings.warn(warning)
 
-        fprm_i_j_k *= (gamma ** w_modes.gamma_weight * kconformal_j_k ** w_modes.conformal_weight)[np.newaxis, :, :]
+        fprm_i_j_k *= (kconformal_j_k ** w_modes.conformal_weight)[np.newaxis, :, :]
 
         # Determine the new time slices.  The set u' is chosen so that on each slice of constant u'_i, the average value
         # of u is precisely u_i.  But then, we have to narrow that set down, so that every physical point on all the


### PR DESCRIPTION
The numerical waveforms produced by SpEC are made dimensionless by scaling by the Christodoulou mass computed early in the simulation. This value should be treated as Lorentz invariant. This PR only needs to change the transformation for `WaveformModes` and `WaveformGrid` objects because the `AsymptoticBondiData` interface assumes the quantites are dimensionful (or that the Christodoulou mass is Lorentz invariant). 

The primary argument for this is from @moble. The following plot shows the value of the Christodoulou mass over the course of the simulation along with a prediction from  [arxiv:gr-qc/0107080](https://arxiv.org/abs/gr-qc/0107080). Here we have the Lev6 mass value (averaged between T=2000 and 5000), and added the integrated change in mass. 
![image](https://user-images.githubusercontent.com/25355745/98040748-ce918f80-1dee-11eb-8240-3be85098a8b3.png)