### PR TITLE
Decode bytes into string before assert, if needed

### DIFF
--- a/tests/test_SpEC.py
+++ b/tests/test_SpEC.py
@@ -77,7 +77,10 @@ def test_file_io(tempdir):
         assert list1 == list2
 
         # Check that original history is contained (with extra comment characters) in second history
-        assert ("# " + "\n# ".join(f1["History.txt"][()].split("\n"))) in f2["History.txt"][()]
+        if isinstance(f2["History.txt"][()], str):
+            assert ("# " + "\n# ".join(f1["History.txt"][()].split("\n"))) in f2["History.txt"][()]
+        else:
+            assert ("# " + "\n# ".join(f1["History.txt"][()].decode("utf-8").split("\n"))) in f2["History.txt"][()].decode("utf-8")
 
         # Now check each mode from the original
         for mode in list(f1):


### PR DESCRIPTION
There is still a failing test `test_file_io` in `test_SpEC.py`. Depending on if the user has installed the dependencies from conda-forge or from conda, `f2["History.txt"][()]` is a byte-string or a string. Unfortunately, this means that the test will fail in one case and pass in another. This should ensure that the test will pass regardless of dependencies used.