### PR TITLE
Fix error message about insufficient number of finite-radius objects

### DIFF
--- a/scri/extrapolation.py
+++ b/scri/extrapolation.py
@@ -1192,9 +1192,9 @@ def _Extrapolate(FiniteRadiusWaveforms, Radii, ExtrapolationOrders, Omegas=None,
             )
         )
         raise ValueError("scri_IndexOutOfBounds")
-    if MaxN > 0 and (MaxN + 1) >= NFiniteRadii:
+    if MaxN > 0 and MaxN >= NFiniteRadii:
         print(
-            "ERROR: Asking for extrapolation up to order {}, but only got {}"
+            "ERROR: Asking for extrapolation up to order {}, but only got {} "
             "finite-radius Waveform objects; need at least {} waveforms.".format(MaxN, NFiniteRadii, MaxN + 1)
         )
         raise ValueError("scri_IndexOutOfBounds")


### PR DESCRIPTION
When you run extrapolation with barely sufficient number of radii the following error warning was triggered.
`ERROR: Asking for extrapolation up to order 4, but only got 5finite-radius Waveform objects; need at least 5 waveforms.`

This PR fixes the consistency check.