### PR TITLE
Fix Github only running pytest on upstream master

### DIFF
--- a/.github/workflows/automated_testing.yml
+++ b/.github/workflows/automated_testing.yml
@@ -20,7 +20,12 @@ jobs:
         echo $CONDA/bin >> $GITHUB_PATH
     - name: Install dependencies
       run: |
+        # install the upstream master branch of scri and all its dependencies
         conda install -c conda-forge scri
+    - name: Install current branch of scri
+      run: |
+        # replace the upstream master branch of scri with the branch that is being tested
+        pip install .
     - name: Lint with flake8
       run: |
         conda install flake8


### PR DESCRIPTION
There was a critical bug in PR #51: it would only use the currently available version of scri on conda-forge (i.e. upstream master) to run the tests. I used the line:
```
conda install -c conda-forge scri
```
to be a quick & easy way to install the dependencies, but I forgot to install the current branch of scri on top of that. 