### PR TITLE
Add several features to ABD

### DIFF
--- a/scri/SpEC/__init__.py
+++ b/scri/SpEC/__init__.py
@@ -5,4 +5,4 @@
 from .._version import __version__
 
 from .com_motion import com_motion, estimate_avg_com_motion, remove_avg_com_motion
-from .file_io import read_from_h5, write_to_h5
+from .file_io import read_from_h5, write_to_h5, create_abd_from_h5

--- a/scri/SpEC/file_io/__init__.py
+++ b/scri/SpEC/file_io/__init__.py
@@ -324,7 +324,7 @@ def read_from_h5(file_name, **kwargs):
 
 def write_to_h5(w, file_name, file_write_mode="w", attributes={}, use_NRAR_format=True):
     """
-    Output the Waveform to an HDF5 file. Default behavior uses the NRAR format. 
+    Output the Waveform to an HDF5 file. Default behavior uses the NRAR format.
 
     Note that the file_name is prepended with some descriptive information involving the data type and the frame type,
     such as 'rhOverM_Corotating_' or 'rMpsi4_Aligned_'.
@@ -469,6 +469,7 @@ def create_abd_from_h5(file_format, convention="SpEC", **kwargs):
 
     if kwargs:
         import pprint
+
         warnings.warn("\nUnused kwargs passed to this function:\n{}".format(pprint.pformat(kwargs, width=1)))
 
     # Sanity check
@@ -483,7 +484,11 @@ def create_abd_from_h5(file_format, convention="SpEC", **kwargs):
             )
 
     # Create an instance of AsymptoticBondiData
-    abd = AsymptoticBondiData(time=WM_ref.t, ell_max=WM_ref.ell_max, multiplication_truncator=max,)
+    abd = AsymptoticBondiData(
+        time=WM_ref.t,
+        ell_max=WM_ref.ell_max,
+        multiplication_truncator=max,
+    )
 
     # Define factors to convert between input waveform convention and Moreschi-Boyle convention
     conversion_factor = {

--- a/scri/SpEC/file_io/__init__.py
+++ b/scri/SpEC/file_io/__init__.py
@@ -480,7 +480,7 @@ def create_abd_from_h5(file_format, convention="SpEC", **kwargs):
         if not (WM_ref.t == WMs[i].t).all():
             raise ValueError(
                 f"All waveforms must share the same set of times. The data "
-                "for {list(WMs.keys())[i].data_type_string} has a different set of times."
+                f"for {list(WMs.keys())[i].data_type_string} has a different set of times."
             )
 
     # Create an instance of AsymptoticBondiData

--- a/scri/asymptotic_bondi_data/__init__.py
+++ b/scri/asymptotic_bondi_data/__init__.py
@@ -205,6 +205,6 @@ class AsymptoticBondiData:
         bondi_angular_momentum,
         bondi_dimensionless_spin,
         bondi_boost_charge,
-        bondi_comoving_CoM_charge,
+        bondi_CoM_charge,
         supermomentum,
     )

--- a/scri/asymptotic_bondi_data/__init__.py
+++ b/scri/asymptotic_bondi_data/__init__.py
@@ -179,12 +179,8 @@ class AsymptoticBondiData:
         new_abd.psi0 = self.psi0.interpolate(new_times)
         # interpolate frame data if necessary
         if self.frame.shape[0] == self.n_times:
-            from scipy.interpolate import CubicSpline
             import quaternion
-
-            frame = quaternion.as_float_array(self.frame)
-            new_frame = CubicSpline(self.t, frame, axis=0)(new_times)
-            new_abd.frame = quaternion.as_quat_array(new_frame)
+            new_abd.frame = quaternion.squad(self.frame, self.t, new_times)
         return new_abd
 
     from .from_initial_values import from_initial_values

--- a/scri/asymptotic_bondi_data/__init__.py
+++ b/scri/asymptotic_bondi_data/__init__.py
@@ -167,4 +167,13 @@ class AsymptoticBondiData:
     )
 
     from .transformations import transform
-    from .bms_charges import mass_aspect, bondi_four_momentum
+    from .bms_charges import (
+        mass_aspect,
+        bondi_rest_mass,
+        bondi_four_momentum,
+        bondi_angular_momentum,
+        bondi_dimensionless_spin,
+        bondi_boost_charge,
+        bondi_comoving_CoM_charge,
+        supermomentum,
+    )

--- a/scri/asymptotic_bondi_data/__init__.py
+++ b/scri/asymptotic_bondi_data/__init__.py
@@ -1,4 +1,3 @@
-from math import sqrt, pi
 import numpy as np
 from spherical_functions import LM_total_size
 from .. import ModesTimeSeries
@@ -155,55 +154,6 @@ class AsymptoticBondiData:
 
     from .from_initial_values import from_initial_values
 
-    def mass_aspect(self, truncate_ell=max):
-        """Compute the Bondi mass aspect of the AsymptoticBondiData
-
-        The Bondi mass aspect is given by
-
-            \\Psi = \\psi_2 + \\eth \\eth \bar{\\sigma} + \\sigma * \\dot{\bar{\\sigma}}
-
-        Note that the last term is a product between two fields.  If, for example, these both have
-        ell_max=8, then their full product would have ell_max=16, meaning that we would go from
-        tracking 77 modes to 289.  This shows that deciding how to truncate the output ell is
-        important, which is why this function has the extra argument that it does.
-
-        Parameters
-        ==========
-        truncate_ell: int, or callable [defaults to `max`]
-            Determines how the ell_max value of the output is determined.  If an integer is passed,
-            each term in the output is truncated to have at most that ell_max.  (In particular,
-            terms that will not be used in the output are simply not computed, without incurring any
-            errors due to aliasing.)  If a callable is passed, it is passed on to the
-            spherical_functions.Modes.multiply method.  See that function's docstring for details.
-            The default behavior will result in the output having ell_max equal to the largest of
-            any of the individual Modes objects in the equation for \\Psi above -- but not the
-            product.
-
-        """
-        if callable(truncate_ell):
-            return self.psi2 + self.sigma.bar.eth.eth + self.sigma.multiply(self.sigma.bar.dot, truncator=truncate_ell)
-        elif truncate_ell:
-            return (
-                self.psi2.truncate_ell(truncate_ell)
-                + self.sigma.bar.eth.eth.truncate_ell(truncate_ell)
-                + self.sigma.multiply(self.sigma.bar.dot, truncator=lambda tup: truncate_ell)
-            )
-        else:
-            return self.psi2 + self.sigma.bar.eth.eth + self.sigma * self.sigma.bar.dot
-
-    @property
-    def bondi_four_momentum(self):
-        """Compute the Bondi four-momentum of the AsymptoticBondiData"""
-        import spherical_functions as sf
-
-        P_restricted = -self.mass_aspect(1).view(np.ndarray) / sqrt(4 * pi)  # Compute only the parts we need, ell<=1
-        four_momentum = np.empty(P_restricted.shape, dtype=float)
-        four_momentum[..., 0] = P_restricted[..., 0].real
-        four_momentum[..., 1] = (P_restricted[..., 3] - P_restricted[..., 1]).real / sqrt(6)
-        four_momentum[..., 2] = (1j * (P_restricted[..., 3] + P_restricted[..., 1])).real / sqrt(6)
-        four_momentum[..., 3] = -P_restricted[..., 2].real / sqrt(3)
-        return four_momentum
-
     from .constraints import (
         bondi_constraints,
         bondi_violations,
@@ -217,3 +167,4 @@ class AsymptoticBondiData:
     )
 
     from .transformations import transform
+    from .bms_charges import mass_aspect, bondi_four_momentum

--- a/scri/asymptotic_bondi_data/bms_charges.py
+++ b/scri/asymptotic_bondi_data/bms_charges.py
@@ -55,8 +55,142 @@ def charge_vector_from_aspect(charge):
     return four_vector / np.sqrt(4 * np.pi)
 
 
+def bondi_rest_mass(self):
+    """Compute the rest mass from the Bondi four-momentum of the AsymptoticBondiData."""
+    four_momentum = self.bondi_four_momentum()
+    rest_mass = np.sqrt(four_momentum[:, 0]**2 - np.sum(four_momentum[:, 1:]**2, axis=1))
+    return rest_mass
+
+
 def bondi_four_momentum(self):
     """Compute the Bondi four-momentum of the AsymptoticBondiData."""
     ell_max = 1  # Compute only the parts we need, ell<=1
     charge_aspect = self.mass_aspect(ell_max).view(np.ndarray)
     return charge_vector_from_aspect(charge_aspect)
+
+
+def bondi_angular_momentum(self, output_dimensionless=False):
+    """Compute the (total) Bondi angular momentum vector of the AsymptoticBondiData via
+    Eq. (8) in T. Dray (1985) [DOI:10.1088/0264-9381/2/1/002]."""
+    ell_max = 1  # Compute only the parts we need, ell<=1
+    charge_aspect = (
+        1j
+        * (self.psi1.truncate_ell(ell_max) + self.sigma.multiply(self.sigma.bar.eth_GHP, truncator=lambda tup: ell_max))
+    ).view(np.ndarray)
+    return charge_vector_from_aspect(charge_aspect)[:, 1:]
+
+
+def bondi_dimensionless_spin(self):
+    """Compute the dimensionless Bondi spin vector of the AsymptoticBondiData."""
+    N = self.bondi_boost_charge()
+    J = self.bondi_angular_momentum()
+    P = self.bondi_four_momentum()
+    M_sqr = (P[:, 0] ** 2 - np.sum(P[:, 1:] ** 2, axis=1))[:, np.newaxis]
+    v = P[:, 1:] / (P[:, 0])[:, np.newaxis]
+    v_norm = np.linalg.norm(v, axis=1)
+    # To prevent dividing by zero, we compute the normalized velocity vhat ONLY at
+    # timesteps with a non-zero velocity.
+    vhat = v.copy()
+    t_idx = v_norm != 0  # Get the indices for timesteps with non-zero velocity
+    vhat[t_idx] = v[t_idx] / v_norm[t_idx, np.newaxis]
+    gamma = (1 / np.sqrt(1 - v_norm ** 2))[:, np.newaxis]
+    J_dot_vhat = np.einsum("ij,ij->i", J, vhat)[:, np.newaxis]
+    spin_charge = (gamma * (J + np.cross(v, N)) - (gamma - 1) * J_dot_vhat * vhat) / M_sqr
+    return spin_charge
+
+
+def bondi_boost_charge(self):
+    """Compute the Bondi boost charge vector of the AsymptoticBondiData via Eq. (8)
+    in T. Dray (1985) [DOI:10.1088/0264-9381/2/1/002]. This gives the boost charge
+    corresponding to the boost with origin at t=0."""
+    ell_max = 1  # Compute only the parts we need, ell<=1
+    charge_aspect = -(
+        self.psi1.truncate_ell(ell_max)
+        + self.sigma.multiply(self.sigma.bar.eth_GHP, truncator=lambda tup: ell_max)
+        + 0.5 * (self.sigma.multiply(self.sigma.bar, truncator=lambda tup: ell_max)).eth_GHP
+        - self.t * (
+            self.psi2.truncate_ell(ell_max)
+            + self.sigma.multiply(self.sigma.bar.dot, truncator=lambda tup: ell_max)
+        ).real.eth_GHP
+    ).view(np.ndarray)
+    return charge_vector_from_aspect(charge_aspect)[:, 1:]
+
+
+def bondi_comoving_CoM_charge(self):
+    """Compute the comoving center-of-mass charge vector defined as:
+
+        G^i = N^i + t*P^i
+
+    where N^i is the boost charge and P^i is the momentum. See Eq. (3.4) and the
+    discussion in arXiv:1912.03164."""
+    ell_max = 1  # Compute only the parts we need, ell<=1
+    charge_aspect = -(
+        self.psi1.truncate_ell(ell_max)
+        + self.sigma.multiply(self.sigma.bar.eth_GHP, truncator=lambda tup: ell_max)
+        + 0.5 * (self.sigma.multiply(self.sigma.bar, truncator=lambda tup: ell_max)).eth_GHP
+    ).view(np.ndarray)
+    return charge_vector_from_aspect(charge_aspect)[:, 1:]
+
+
+def supermomentum(self, supermomentum_def, **kwargs):
+    """Computes the supermomentum of the AsymptoticBondiData. Allows for several different definitions
+    of the supermomentum. These differences only apply to ell > 1 modes, so they do not affect the Bondi
+    four-momentum. See Eqs. (7-9) in arXiv:1404.2475 for the different supermomentum definitions and links
+    to further references.
+
+    In the literature, there is an ambiguity of vocabulary. When it comes to other BMS charges, we clearly
+    distinuish between the "charge" and the "aspect". However, the term "supermomentum" is used for both.
+    Accordingly, this function provides two ways to compute the supermomentum.
+
+    1) By default, the supermomentum will be computed as:
+
+        \\Psi = \\psi_2 + \\sigma * \\dot{\\bar{\\sigma}} + f(\\theta,\\phi)
+
+    2) By passing the option 'integrated=True', the supermomentum will instead be computed as:
+
+        P_{\\ell,m} = - \\frac{1}{4\\pi} \int \\Psi(\\theta,\\phi) Y_{\\ell,m} (\\theta,\\phi) d\\Omega
+
+    Parameters
+    ----------
+    supermomentum_def : str
+        The definition of the supermomentum to be computed. One of the following options (case insensitive)
+        can be specified:
+          * 'Bondi-Sachs' or 'BS'
+          * 'Moreschi' or 'M'
+          * 'Geroch' or 'G'
+          * 'Geroch-Winicour' or 'GW'
+    integrated : bool, default: False
+        If true, then return the integrated form of the supermomentum. See Eq. (6) in arXiv:1404.2475.
+
+    Returns
+    -------
+    ModesTimeSeries
+
+    """
+    return_integrated = kwargs.pop("integrated") if "integrated" in kwargs else False
+
+    if supermomentum_def.lower() in ["bondi-sachs", "bs"]:
+        supermomentum = self.psi2 + self.sigma * self.sigma.bar.dot
+    elif supermomentum_def.lower() in ["moreschi", "m"]:
+        supermomentum = self.psi2 + self.sigma * self.sigma.bar.dot + self.sigma.bar.eth_GHP.eth_GHP
+    elif supermomentum_def.lower() in ["geroch", "g"]:
+        supermomentum = (
+            self.psi2
+            + self.sigma * self.sigma.bar.dot
+            + 0.5 * (self.sigma.bar.eth_GHP.eth_GHP - self.sigma.ethbar_GHP.ethbar_GHP)
+        )
+    elif supermomentum_def.lower() in ["geroch-winicour", "gw"]:
+        supermomentum = self.psi2 + self.sigma * self.sigma.bar.dot - self.sigma.ethbar_GHP.ethbar_GHP
+    else:
+        raise ValueError(
+            f"Supermomentum defintion '{supermomentum_def}' not recognized. Please choose one of "
+            "the following options:\n"
+            "  * 'Bondi-Sachs' or 'BS'\n"
+            "  * 'Moreschi' or 'M'\n"
+            "  * 'Geroch' or 'G'\n"
+            "  * 'Geroch-Winicour' or 'GW'"
+        )
+    if return_integrated:
+        return -0.5 * supermomentum.bar / np.sqrt(np.pi)
+    else:
+        return supermomentum

--- a/scri/asymptotic_bondi_data/bms_charges.py
+++ b/scri/asymptotic_bondi_data/bms_charges.py
@@ -10,11 +10,11 @@ from math import sqrt, pi
 
 
 def mass_aspect(self, truncate_ell=max):
-    """Compute the Bondi mass aspect of the AsymptoticBondiData
+    """Compute the Bondi mass aspect of the AsymptoticBondiData.
 
     The Bondi mass aspect is given by
 
-        \\Psi = \\psi_2 + \\eth \\eth \\bar{\\sigma} + \\sigma * \\dot{\\bar{\\sigma}}
+        M = -Re(\\psi_2 + \\sigma * \\dot{\\bar{\\sigma}})
 
     Note that the last term is a product between two fields.  If, for example, these both have
     ell_max=8, then their full product would have ell_max=16, meaning that we would go from
@@ -30,30 +30,33 @@ def mass_aspect(self, truncate_ell=max):
         errors due to aliasing.)  If a callable is passed, it is passed on to the
         spherical_functions.Modes.multiply method.  See that function's docstring for details.
         The default behavior will result in the output having ell_max equal to the largest of
-        any of the individual Modes objects in the equation for \\Psi above -- but not the
+        any of the individual Modes objects in the equation for M above -- but not the
         product.
 
     """
     if callable(truncate_ell):
-        return self.psi2 + self.sigma.bar.eth_GHP.eth_GHP + self.sigma.multiply(self.sigma.bar.dot, truncator=truncate_ell)
+        return -(self.psi2 + self.sigma.multiply(self.sigma.bar.dot, truncator=truncate_ell))
     elif truncate_ell:
-        return (
+        return -(
             self.psi2.truncate_ell(truncate_ell)
-            + self.sigma.bar.eth_GHP.eth_GHP.truncate_ell(truncate_ell)
             + self.sigma.multiply(self.sigma.bar.dot, truncator=lambda tup: truncate_ell)
-        )
+        ).real
     else:
-        return self.psi2 + self.sigma.bar.eth_GHP.eth_GHP + self.sigma * self.sigma.bar.dot
+        return -(self.psi2 + self.sigma * self.sigma.bar.dot).real
+
+
+def charge_vector_from_aspect(charge):
+    """Output the ell<=1 modes of a BMS charge aspect as the charge four-vector."""
+    four_vector = np.empty(charge.shape, dtype=float)
+    four_vector[..., 0] = charge[..., 0].real
+    four_vector[..., 1] = (charge[..., 1] - charge[..., 3]).real / sqrt(6)
+    four_vector[..., 2] = (charge[..., 1] + charge[..., 3]).imag / sqrt(6)
+    four_vector[..., 3] = charge[..., 2].real / sqrt(3)
+    return four_vector / np.sqrt(4 * np.pi)
 
 
 def bondi_four_momentum(self):
-    """Compute the Bondi four-momentum of the AsymptoticBondiData"""
-    import spherical_functions as sf
-
-    P_restricted = -self.mass_aspect(1).view(np.ndarray) / sqrt(4 * pi)  # Compute only the parts we need, ell<=1
-    four_momentum = np.empty(P_restricted.shape, dtype=float)
-    four_momentum[..., 0] = P_restricted[..., 0].real
-    four_momentum[..., 1] = (P_restricted[..., 3] - P_restricted[..., 1]).real / sqrt(6)
-    four_momentum[..., 2] = (1j * (P_restricted[..., 3] + P_restricted[..., 1])).real / sqrt(6)
-    four_momentum[..., 3] = -P_restricted[..., 2].real / sqrt(3)
-    return four_momentum
+    """Compute the Bondi four-momentum of the AsymptoticBondiData."""
+    ell_max = 1  # Compute only the parts we need, ell<=1
+    charge_aspect = self.mass_aspect(ell_max).view(np.ndarray)
+    return charge_vector_from_aspect(charge_aspect)

--- a/scri/asymptotic_bondi_data/bms_charges.py
+++ b/scri/asymptotic_bondi_data/bms_charges.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2020, Michael Boyle
+# See LICENSE file for details: <https://github.com/moble/scri/blob/master/LICENSE>
+
+### NOTE: The functions in this file are intended purely for inclusion in the AsymptoticBondData
+### class.  In particular, they assume that the first argument, `self` is an instance of
+### AsymptoticBondData.  They should probably not be used outside of that class.
+
+import numpy as np
+from math import sqrt, pi
+
+
+def mass_aspect(self, truncate_ell=max):
+    """Compute the Bondi mass aspect of the AsymptoticBondiData
+
+    The Bondi mass aspect is given by
+
+        \\Psi = \\psi_2 + \\eth \\eth \\bar{\\sigma} + \\sigma * \\dot{\\bar{\\sigma}}
+
+    Note that the last term is a product between two fields.  If, for example, these both have
+    ell_max=8, then their full product would have ell_max=16, meaning that we would go from
+    tracking 81 modes to 289.  This shows that deciding how to truncate the output ell is
+    important, which is why this function has the extra argument that it does.
+
+    Parameters
+    ==========
+    truncate_ell: int, or callable [defaults to `max`]
+        Determines how the ell_max value of the output is determined.  If an integer is passed,
+        each term in the output is truncated to have at most that ell_max.  (In particular,
+        terms that will not be used in the output are simply not computed, without incurring any
+        errors due to aliasing.)  If a callable is passed, it is passed on to the
+        spherical_functions.Modes.multiply method.  See that function's docstring for details.
+        The default behavior will result in the output having ell_max equal to the largest of
+        any of the individual Modes objects in the equation for \\Psi above -- but not the
+        product.
+
+    """
+    if callable(truncate_ell):
+        return self.psi2 + self.sigma.bar.eth_GHP.eth_GHP + self.sigma.multiply(self.sigma.bar.dot, truncator=truncate_ell)
+    elif truncate_ell:
+        return (
+            self.psi2.truncate_ell(truncate_ell)
+            + self.sigma.bar.eth_GHP.eth_GHP.truncate_ell(truncate_ell)
+            + self.sigma.multiply(self.sigma.bar.dot, truncator=lambda tup: truncate_ell)
+        )
+    else:
+        return self.psi2 + self.sigma.bar.eth_GHP.eth_GHP + self.sigma * self.sigma.bar.dot
+
+
+def bondi_four_momentum(self):
+    """Compute the Bondi four-momentum of the AsymptoticBondiData"""
+    import spherical_functions as sf
+
+    P_restricted = -self.mass_aspect(1).view(np.ndarray) / sqrt(4 * pi)  # Compute only the parts we need, ell<=1
+    four_momentum = np.empty(P_restricted.shape, dtype=float)
+    four_momentum[..., 0] = P_restricted[..., 0].real
+    four_momentum[..., 1] = (P_restricted[..., 3] - P_restricted[..., 1]).real / sqrt(6)
+    four_momentum[..., 2] = (1j * (P_restricted[..., 3] + P_restricted[..., 1])).real / sqrt(6)
+    four_momentum[..., 3] = -P_restricted[..., 2].real / sqrt(3)
+    return four_momentum

--- a/scri/asymptotic_bondi_data/bms_charges.py
+++ b/scri/asymptotic_bondi_data/bms_charges.py
@@ -161,6 +161,10 @@ def supermomentum(self, supermomentum_def, **kwargs):
           * 'Geroch-Winicour' or 'GW'
     integrated : bool, default: False
         If true, then return the integrated form of the supermomentum. See Eq. (6) in arXiv:1404.2475.
+    working_ell_max: int, optional
+        The value of ell_max to be used to define the computation grid. The
+        number of theta points and the number of phi points are set to
+        2*working_ell_max+1. Defaults to 2*self.ell_max.
 
     Returns
     -------
@@ -170,17 +174,17 @@ def supermomentum(self, supermomentum_def, **kwargs):
     return_integrated = kwargs.pop("integrated") if "integrated" in kwargs else False
 
     if supermomentum_def.lower() in ["bondi-sachs", "bs"]:
-        supermomentum = self.psi2 + self.sigma * self.sigma.bar.dot
+        supermomentum = self.psi2 + self.sigma.grid_multiply(self.sigma.bar.dot, **kwargs)
     elif supermomentum_def.lower() in ["moreschi", "m"]:
-        supermomentum = self.psi2 + self.sigma * self.sigma.bar.dot + self.sigma.bar.eth_GHP.eth_GHP
+        supermomentum = self.psi2 + self.sigma.grid_multiply(self.sigma.bar.dot, **kwargs) + self.sigma.bar.eth_GHP.eth_GHP
     elif supermomentum_def.lower() in ["geroch", "g"]:
         supermomentum = (
             self.psi2
-            + self.sigma * self.sigma.bar.dot
+            + self.sigma.grid_multiply(self.sigma.bar.dot, **kwargs)
             + 0.5 * (self.sigma.bar.eth_GHP.eth_GHP - self.sigma.ethbar_GHP.ethbar_GHP)
         )
     elif supermomentum_def.lower() in ["geroch-winicour", "gw"]:
-        supermomentum = self.psi2 + self.sigma * self.sigma.bar.dot - self.sigma.ethbar_GHP.ethbar_GHP
+        supermomentum = self.psi2 + self.sigma.grid_multiply(self.sigma.bar.dot, **kwargs) - self.sigma.ethbar_GHP.ethbar_GHP
     else:
         raise ValueError(
             f"Supermomentum defintion '{supermomentum_def}' not recognized. Please choose one of "

--- a/scri/asymptotic_bondi_data/bms_charges.py
+++ b/scri/asymptotic_bondi_data/bms_charges.py
@@ -75,7 +75,7 @@ def bondi_four_momentum(self):
 
 def bondi_angular_momentum(self, output_dimensionless=False):
     """Compute the total Bondi angular momentum vector
-    
+
         i (ψ₁ + σ ðσ̄)
 
     See Eq. (8) of Dray (1985) iopscience.iop.org/article/10.1088/0264-9381/2/1/002
@@ -110,7 +110,7 @@ def bondi_dimensionless_spin(self):
 
 def bondi_boost_charge(self):
     """Compute the Bondi boost charge vector
-    
+
         - [ψ₁ + σ ðσ̄ + ½ð(σ σ̄) - t ð ℜ{ψ₂ + σ ∂ₜσ̄}]
 
     See Eq. (8) of Dray (1985) iopscience.iop.org/article/10.1088/0264-9381/2/1/002
@@ -129,8 +129,8 @@ def bondi_boost_charge(self):
     return charge_vector_from_aspect(charge_aspect)[:, 1:]
 
 
-def bondi_comoving_CoM_charge(self):
-    """Compute the comoving center-of-mass charge vector
+def bondi_CoM_charge(self):
+    """Compute the center-of-mass charge vector
 
         Gⁱ = Nⁱ + t Pⁱ = - [ψ₁ + σ ðσ̄ + ½ð(σ σ̄)]
 

--- a/scri/asymptotic_bondi_data/bms_charges.py
+++ b/scri/asymptotic_bondi_data/bms_charges.py
@@ -35,7 +35,7 @@ def mass_aspect(self, truncate_ell=max):
 
     """
     if callable(truncate_ell):
-        return -(self.psi2 + self.sigma.multiply(self.sigma.bar.dot, truncator=truncate_ell))
+        return -(self.psi2 + self.sigma.multiply(self.sigma.bar.dot, truncator=truncate_ell)).real
     elif truncate_ell:
         return -(
             self.psi2.truncate_ell(truncate_ell)

--- a/scri/asymptotic_bondi_data/bms_charges.py
+++ b/scri/asymptotic_bondi_data/bms_charges.py
@@ -58,7 +58,7 @@ def charge_vector_from_aspect(charge):
 def bondi_rest_mass(self):
     """Compute the rest mass from the Bondi four-momentum of the AsymptoticBondiData."""
     four_momentum = self.bondi_four_momentum()
-    rest_mass = np.sqrt(four_momentum[:, 0]**2 - np.sum(four_momentum[:, 1:]**2, axis=1))
+    rest_mass = np.sqrt(four_momentum[:, 0] ** 2 - np.sum(four_momentum[:, 1:] ** 2, axis=1))
     return rest_mass
 
 
@@ -108,9 +108,9 @@ def bondi_boost_charge(self):
         self.psi1.truncate_ell(ell_max)
         + self.sigma.multiply(self.sigma.bar.eth_GHP, truncator=lambda tup: ell_max)
         + 0.5 * (self.sigma.multiply(self.sigma.bar, truncator=lambda tup: ell_max)).eth_GHP
-        - self.t * (
-            self.psi2.truncate_ell(ell_max)
-            + self.sigma.multiply(self.sigma.bar.dot, truncator=lambda tup: ell_max)
+        - self.t
+        * (
+            self.psi2.truncate_ell(ell_max) + self.sigma.multiply(self.sigma.bar.dot, truncator=lambda tup: ell_max)
         ).real.eth_GHP
     ).view(np.ndarray)
     return charge_vector_from_aspect(charge_aspect)[:, 1:]

--- a/scri/asymptotic_bondi_data/bms_charges.py
+++ b/scri/asymptotic_bondi_data/bms_charges.py
@@ -46,7 +46,17 @@ def mass_aspect(self, truncate_ell=max):
 
 
 def charge_vector_from_aspect(charge):
-    """Output the ell<=1 modes of a BMS charge aspect as the charge four-vector."""
+    """Output the ell<=1 modes of a BMS charge aspect as the charge four-vector.
+
+    Considering the aspect as a function a(θ, ϕ), we express the corresponding
+    four-vector in terms of Cartesian components as
+
+      vᵝ = (1/4π) ∫ ℜ{a} (tᵝ + rᵝ) dΩ
+
+    where the integral is taken over the 2-sphere, and tᵝ + rᵝ has components
+    (1, sinθ cosϕ, sinθ sinϕ, cosθ).
+
+    """
     four_vector = np.empty(charge.shape, dtype=float)
     four_vector[..., 0] = charge[..., 0].real
     four_vector[..., 1] = (charge[..., 1] - charge[..., 3]).real / sqrt(6)

--- a/scri/asymptotic_bondi_data/transformations.py
+++ b/scri/asymptotic_bondi_data/transformations.py
@@ -315,9 +315,7 @@ def transform(self, **kwargs):
     u = self.u
     α = sf.Grid(supertranslation.evaluate(distorted_grid_rotors), spin_weight=0).real[np.newaxis, :, :]
     # The factors of 1/sqrt(2) and 1/2 come from using the GHP eth instead of the NP eth.
-    ðα = sf.Grid(supertranslation.eth.evaluate(distorted_grid_rotors) / np.sqrt(2), spin_weight=α.s + 1)[
-        np.newaxis, :, :
-    ]
+    ðα = sf.Grid(supertranslation.eth.evaluate(distorted_grid_rotors) / np.sqrt(2), spin_weight=α.s + 1)[np.newaxis, :, :]
     ððα = sf.Grid(0.5 * supertranslation.eth.eth.evaluate(distorted_grid_rotors), spin_weight=α.s + 2)[np.newaxis, :, :]
     k, ðk_over_k, one_over_k, one_over_k_cubed = conformal_factors(boost_velocity, distorted_grid_rotors)
 

--- a/scri/asymptotic_bondi_data/transformations.py
+++ b/scri/asymptotic_bondi_data/transformations.py
@@ -287,9 +287,13 @@ def transform(self, **kwargs):
     from scipy.interpolate import CubicSpline
 
     # Parse the input arguments, and define the basic parameters for this function
-    frame_rotation, boost_velocity, supertranslation, working_ell_max, output_ell_max, = _process_transformation_kwargs(
-        self.ell_max, **kwargs
-    )
+    (
+        frame_rotation,
+        boost_velocity,
+        supertranslation,
+        working_ell_max,
+        output_ell_max,
+    ) = _process_transformation_kwargs(self.ell_max, **kwargs)
     n_theta = 2 * working_ell_max + 1
     n_phi = n_theta
     β = np.linalg.norm(boost_velocity)
@@ -311,8 +315,10 @@ def transform(self, **kwargs):
     u = self.u
     α = sf.Grid(supertranslation.evaluate(distorted_grid_rotors), spin_weight=0).real[np.newaxis, :, :]
     # The factors of 1/sqrt(2) and 1/2 come from using the GHP eth instead of the NP eth.
-    ðα = sf.Grid(supertranslation.eth.evaluate(distorted_grid_rotors)/np.sqrt(2), spin_weight=α.s + 1)[np.newaxis, :, :]
-    ððα = sf.Grid(0.5*supertranslation.eth.eth.evaluate(distorted_grid_rotors), spin_weight=α.s + 2)[np.newaxis, :, :]
+    ðα = sf.Grid(supertranslation.eth.evaluate(distorted_grid_rotors) / np.sqrt(2), spin_weight=α.s + 1)[
+        np.newaxis, :, :
+    ]
+    ððα = sf.Grid(0.5 * supertranslation.eth.eth.evaluate(distorted_grid_rotors), spin_weight=α.s + 2)[np.newaxis, :, :]
     k, ðk_over_k, one_over_k, one_over_k_cubed = conformal_factors(boost_velocity, distorted_grid_rotors)
 
     # ðu'(u, θ', ϕ') exp(iλ) / k(θ', ϕ')

--- a/scri/extrapolation.py
+++ b/scri/extrapolation.py
@@ -4,10 +4,7 @@ mode_regex = r"""Y_l(?P<L>[0-9]+)_m(?P<M>[-+0-9]+)\.dat"""
 
 
 def pick_Ch_mass(filename="Horizons.h5"):
-    """
-    Deduce the best Christodoulou mass by finding the statistical "mode" (after
-    binning).
-    """
+    """Deduce the best Christodoulou mass by finding the statistical "mode" (after binning)."""
     from h5py import File
     from os.path import isdir
     from numpy import histogram
@@ -26,9 +23,7 @@ def pick_Ch_mass(filename="Horizons.h5"):
 
 
 def monotonic_indices(T, MinTimeStep=1.0e-3):
-    """
-    Given an array of times, return the indices that make the array strictly monotonic.
-    """
+    """Given an array of times, return the indices that make the array strictly monotonic."""
     from numpy import delete
 
     Ind = range(len(T))
@@ -62,6 +57,10 @@ def intersection(t1, t2, min_step=None, min_time=None, max_time=None):
     min_step: float
     min_time: float
     max_time: float
+
+    Returns
+    -------
+    1-d float array
 
     """
     import numpy as np
@@ -134,7 +133,10 @@ def validate_single_waveform(h5file, filename, WaveformName, ExpectedNModes, Exp
         Valid = False
         print(
             "{}:{}/ArealRadius.dat\n\tGot shape {}; expected ({}, 2)".format(
-                filename, WaveformName, h5file[WaveformName + "/ArealRadius.dat"].shape, ExpectedNTimes,
+                filename,
+                WaveformName,
+                h5file[WaveformName + "/ArealRadius.dat"].shape,
+                ExpectedNTimes,
             )
         )
     # Check AverageLapse
@@ -142,7 +144,10 @@ def validate_single_waveform(h5file, filename, WaveformName, ExpectedNModes, Exp
         Valid = False
         print(
             "{}:{}/AverageLapse.dat\n\tGot shape {}; expected ({}, 2)".format(
-                filename, WaveformName, h5file[WaveformName + "/AverageLapse.dat"].shape, ExpectedNTimes,
+                filename,
+                WaveformName,
+                h5file[WaveformName + "/AverageLapse.dat"].shape,
+                ExpectedNTimes,
             )
         )
     # Check Y_l*_m*.dat
@@ -165,7 +170,11 @@ def validate_single_waveform(h5file, filename, WaveformName, ExpectedNModes, Exp
                 Valid = False
                 (
                     "{}:{}/{}\n\tGot shape {}; expected ({}, 3)".format(
-                        filename, WaveformName, dataset, h5file[WaveformName + "/" + dataset].shape, ExpectedNTimes,
+                        filename,
+                        WaveformName,
+                        dataset,
+                        h5file[WaveformName + "/" + dataset].shape,
+                        ExpectedNTimes,
                     )
                 )
     return Valid
@@ -198,10 +207,8 @@ def validate_group_of_waveforms(h5file, filename, WaveformNames, LModes):
 def read_finite_radius_waveform(
     n, filename, WaveformName, ChMass, InitialAdmEnergy, YLMRegex, LModes, DataType, VersionHist, Ws,
 ):
-    """
-    This is just a worker function defined for read_finite_radius_data,
-    below, reading a single waveform from an h5 file of many
-    waveforms.  You probably don't need to call this directly.
+    """This is just a worker function defined for read_finite_radius_data, below, reading a single
+    waveform from an h5 file of many waveforms. You probably don't need to call this directly.
 
     """
     from scipy.integrate import cumtrapz as integrate
@@ -213,7 +220,15 @@ def read_finite_radius_waveform(
         """# extrapolation.read_finite_radius_waveform""" + """({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, Ws)"""
     )
     construction = construction.format(
-        n, filename, WaveformName, ChMass, InitialAdmEnergy, YLMRegex.pattern, LModes, DataType, VersionHist,
+        n,
+        filename,
+        WaveformName,
+        ChMass,
+        InitialAdmEnergy,
+        YLMRegex.pattern,
+        LModes,
+        DataType,
+        VersionHist,
     )
     try:
         f = File(filename, "r")
@@ -294,10 +309,7 @@ def read_finite_radius_waveform(
 def read_finite_radius_data(
     ChMass=0.0, filename="rh_FiniteRadii_CodeUnits.h5", CoordRadii=[], LModes=range(2, 100),
 ):
-    """
-    Read data at various radii, and offset by tortoise coordinate.
-
-    """
+    """Read data at various radii, and offset by tortoise coordinate."""
 
     if ChMass == 0.0:
         raise ValueError("ChMass=0.0 is not a valid input value.")
@@ -391,8 +403,7 @@ def read_finite_radius_data(
 
 
 def set_common_time(Ws, Radii, MinTimeStep=0.005, EarliestTime=-3e300, LatestTime=3e300):
-    """Interpolate Waveforms and radius data to a common set of times
-    """
+    """Interpolate Waveforms and radius data to a common set of times."""
     from scipy import interpolate
 
     NWaveforms = len(Radii)
@@ -409,101 +420,103 @@ def set_common_time(Ws, Radii, MinTimeStep=0.005, EarliestTime=-3e300, LatestTim
 
 
 def extrapolate(**kwargs):
-    """Perform extrapolations from finite-radius data
-    ==============================================
-      Parameters
-      ----------
-        InputDirectory           './'
-          Where to find the input data.  Can be relative or absolute.
+    """Perform extrapolations from finite-radius data.
 
-        OutputDirectory          './'
-          This directory will be made if it does not exist.
+    See arXiv:2010.15200 for specific details.
 
-        DataFile                 'rh_FiniteRadii_CodeUnits.h5'
-          Input file holding the data from all the radii.
+    Parameters
+    ----------
+      InputDirectory : str, (Default: './')
+        Where to find the input data.  Can be relative or absolute.
 
-        ChMass                   0.0
-          Christodoulou mass in the same units as the rest of the
-          data.  All the data will be rescaled into units such that
-          this is one.  If this is zero, the Christodoulou mass will
-          be extracted automatically from the horizons file below.
+      OutputDirectory : str, (Default: './')
+        This directory will be made if it does not exist.
 
-        HorizonsFile             'Horizons.h5'
-          File name to read for horizon data (if ChMass is 0.0).
+      DataFile : str, (Default: 'rh_FiniteRadii_CodeUnits.h5')
+        Input file holding the data from all the radii.
 
-        CoordRadii               []
-          List of strings containing the radii to use, or of (integer)
-          indices of the list of waveform names.  If this is a list of
-          indices, the order is just the order output by the command
-          `list(h5py.File(DataFile))` which *should* be the same as
-          `h5ls`.  If the list is empty, all radii that can be found
-          are used.
+      ChMass : float, (Default: 0.0)
+        Christodoulou mass in the same units as the rest of the
+        data.  All the data will be rescaled into units such that
+        this is one.  If this is zero, the Christodoulou mass will
+        be extracted automatically from the horizons file below.
 
-        LModes                   range(abs(s),100)
-          List of ell modes to extrapolate, is the spin-weight of the
-          waveform to be extrapolated.
+      HorizonsFile : str, (Default: 'Horizons.h5')
+        File name to read for horizon data (if ChMass is 0.0).
 
-        ExtrapolationOrders      [-1, 2, 3, 4, 5, 6]
-          Negative numbers correspond to extracted data, counting down
-          from the outermost extraction radius (which is -1).
+      CoordRadii : list of str or list of int, (Default: [])
+        List of strings containing the radii to use, or of (integer)
+        indices of the list of waveform names.  If this is a list of
+        indices, the order is just the order output by the command
+        `list(h5py.File(DataFile))` which *should* be the same as
+        `h5ls`.  If the list is empty, all radii that can be found
+        are used.
 
-        UseOmega                 False
-          Whether or not to extrapolate as a function of lambda/r =
-          1/(r*m*omega), where omega is the instantaneous angular
-          frequency of rotation.  If this is True, the extrapolation
-          will usually not converge for high N; if this is False, SVD
-          will generally cause the convergence to appear to fall to
-          roundoff, though the accuracy presumably is not so great.
+      LModes : list of int, (Default: range(abs(s),100))
+        List of ell modes to extrapolate, is the spin-weight of the
+        waveform to be extrapolated.
 
-        OutputFrame              scri.Inertial
-          Transform to this frame before comparison and output.
+      ExtrapolationOrders : list of int, (Default: [-1, 2, 3, 4, 5, 6])
+        Negative numbers correspond to extracted data, counting down
+        from the outermost extraction radius (which is -1).
 
-        ExtrapolatedFiles        'Extrapolated_N{N}.h5'
-        DifferenceFiles          'ExtrapConvergence_N{N}-N{Nm1}.h5'
-          These are python-formatted output file names, where the
-          extrapolation order N is substituted for '{N}', and the
-          previous extrapolation order is substituted for '{Nm1}'.
-          The data-type inferred from the DataFile name is prepended.
-          If DifferenceFiles is empty, the corresponding file is not
-          output.
+      UseOmega : bool, (Default: False)
+        Whether or not to extrapolate as a function of lambda/r =
+        1/(r*m*omega), where omega is the instantaneous angular
+        frequency of rotation.  If this is True, the extrapolation
+        will usually not converge for high N; if this is False, SVD
+        will generally cause the convergence to appear to fall to
+        roundoff, though the accuracy presumably is not so great.
 
-        UseStupidNRARFormat      False
-          If True (and `ExtrapolatedFiles` does not end in '.dat'),
-          then the h5 output format will be that stupid, old
-          NRAR/NINJA format that doesn't convey enough information,
-          is slow, and uses 33% more space than it needs to.  But you
-          know, if you're into that kind of thing, whatever.  Who am
-          I to judge?
+      OutputFrame : {scri.Inertial, scri.Corotating}
+        Transform to this frame before comparison and output.
 
-        PlotFormat               'pdf'
-          The format of output plots.  This can be the empty string,
-          in which case no plotting is done.  Or, these can be any of
-          the formats supported by your installation of matplotlib.
+      ExtrapolatedFiles : str, (Default: 'Extrapolated_N{N}.h5')
+      DifferenceFiles   : str, (Default: 'ExtrapConvergence_N{N}-N{Nm1}.h5')
+        These are python-formatted output file names, where the
+        extrapolation order N is substituted for '{N}', and the
+        previous extrapolation order is substituted for '{Nm1}'.
+        The data-type inferred from the DataFile name is prepended.
+        If DifferenceFiles is empty, the corresponding file is not
+        output.
 
-        MinTimeStep              0.005
-          The smallest allowed time step in the output data.
+      UseStupidNRARFormat : bool, (Default: False)
+        If True (and `ExtrapolatedFiles` does not end in '.dat'),
+        then the h5 output format will be that stupid, old
+        NRAR/NINJA format that doesn't convey enough information,
+        is slow, and uses 33% more space than it needs to.  But you
+        know, if you're into that kind of thing, whatever.  Who am
+        I to judge?
 
-        EarliestTime             -3.0e300
-          The earliest time in the output data.  For values less than
-          0, some of the data corresponds to times when only junk
-          radiation is present.
+      PlotFormat : str, (Default: 'pdf')
+        The format of output plots.  This can be the empty string,
+        in which case no plotting is done.  Or, these can be any of
+        the formats supported by your installation of matplotlib.
 
-        LatestTime               3.0e300
-          The latest time in the output data.
+      MinTimeStep : float, (Default: 0.005)
+        The smallest allowed time step in the output data.
 
-        AlignmentTime            None
-          The time at which to align the Waveform with the dominant
-          eigenvector of <LL>.  If the input value is `None` or is
-          outside of the input data, it will be reset to the midpoint
-          of the waveform: (W_outer.T(0)+W_outer.T(-1))/2
+      EarliestTime : float, (Default: -3.0e300)
+        The earliest time in the output data.  For values less than
+        0, some of the data corresponds to times when only junk
+        radiation is present.
 
-        NoiseFloor                 None
-          ONLY USED FOR Psi1 AND Psi0 WAVEFORMS.
-          The effective noise floor of the SpEC simulation.
-          If Psi1 or Psi0 (NOT scaled by radius) falls beneath
-          this value for certain extraction radii, then those
-          radii are not included in the extrapolation. The value
-          1.0e-9 seems to work well for a few BBH systems.
+      LatestTime : float, (Default: 3.0e300)
+        The latest time in the output data.
+
+      AlignmentTime : float, (Default: None)
+        The time at which to align the Waveform with the dominant
+        eigenvector of <LL>.  If the input value is `None` or is
+        outside of the input data, it will be reset to the midpoint
+        of the waveform: (W_outer.T(0)+W_outer.T(-1))/2
+
+      NoiseFloor : float, (Default: None)
+        ONLY USED FOR Psi1 AND Psi0 WAVEFORMS.
+        The effective noise floor of the SpEC simulation.
+        If Psi1 or Psi0 (NOT scaled by radius) falls beneath
+        this value for certain extraction radii, then those
+        radii are not included in the extrapolation. The value
+        1.0e-9 seems to work well for a few BBH systems.
 
     """
 
@@ -855,7 +868,9 @@ def extrapolate(**kwargs):
                     ArgDiff -= 2 * pi * round(ArgDiff[len(ArgDiff) // 3] / (2 * pi))
                 plt.figure(0)
                 plt.semilogy(
-                    Diff.t, AbsDiff, label=r"$(N={}) - (N={})$".format(ExtrapolationOrder, ExtrapolationOrders[i - 1]),
+                    Diff.t,
+                    AbsDiff,
+                    label=r"$(N={}) - (N={})$".format(ExtrapolationOrder, ExtrapolationOrders[i - 1]),
                 )
                 plt.figure(1)
                 plt.semilogy(
@@ -888,6 +903,7 @@ def extrapolate(**kwargs):
         plt.gca().axvline(x=MaxNormTime, ls="--")
         try:
             from matplotlib.pyplot import tight_layout
+
             tight_layout(pad=0.5)
         except:
             pass
@@ -965,8 +981,7 @@ def extrapolate(**kwargs):
 
 # Local utility function
 def _safe_format(s, **keys):
-    """
-    Like str.format, but doesn't mind missing arguments.
+    """Like str.format, but doesn't mind missing arguments.
 
     This function is used to replace strings like '{SomeKey}' in
     the template with the arguments given as keys.  For example,
@@ -976,6 +991,7 @@ def _safe_format(s, **keys):
     returns 'Hello {SomeOtherKey}', without errors, ignoring the
     `SomeMissingKey` argument, and not bothering with
     '{SomeOtherKey}', so that that can be replaced later.
+
     """
 
     class Default(dict):
@@ -988,10 +1004,7 @@ def _safe_format(s, **keys):
 
 
 def UnstartedExtrapolations(TopLevelOutputDir, SubdirectoriesAndDataFiles):
-    """
-    Find unstarted extrapolation directories
-
-    """
+    """Find unstarted extrapolation directories."""
     from os.path import exists
 
     Unstarted = []
@@ -1003,10 +1016,7 @@ def UnstartedExtrapolations(TopLevelOutputDir, SubdirectoriesAndDataFiles):
 
 
 def NewerDataThanExtrapolation(TopLevelInputDir, TopLevelOutputDir, SubdirectoriesAndDataFiles):
-    """
-    Find newer data than extrapolation
-
-    """
+    """Find newer data than extrapolation."""
     from os.path import exists, getmtime
 
     Newer = []
@@ -1022,10 +1032,7 @@ def NewerDataThanExtrapolation(TopLevelInputDir, TopLevelOutputDir, Subdirectori
 
 
 def StartedButUnfinishedExtrapolations(TopLevelOutputDir, SubdirectoriesAndDataFiles):
-    """
-    Find directories with extrapolations that started but didn't finish.
-
-    """
+    """Find directories with extrapolations that started but didn't finish."""
     from os.path import exists
 
     Unfinished = []
@@ -1039,10 +1046,7 @@ def StartedButUnfinishedExtrapolations(TopLevelOutputDir, SubdirectoriesAndDataF
 
 
 def ErroredExtrapolations(TopLevelOutputDir, SubdirectoriesAndDataFiles):
-    """
-    Find directories with errors
-
-    """
+    """Find directories with errors."""
     from os.path import exists
 
     Errored = []
@@ -1054,10 +1058,7 @@ def ErroredExtrapolations(TopLevelOutputDir, SubdirectoriesAndDataFiles):
 
 
 def FindPossibleExtrapolationsToRun(TopLevelInputDir):
-    """
-    Find all possible extrapolations
-
-    """
+    """Find all possible extrapolations."""
     from os import walk
     from re import compile as re_compile
 
@@ -1136,7 +1137,11 @@ def RunExtrapolation(TopLevelInputDir, TopLevelOutputDir, Subdirectory, DataFile
             print(
                 "\n\nRunExtrapolation got an error ({4}) on "
                 + "['{}', '{}', '{}', '{}'].\n\n".format(
-                    TopLevelInputDir, TopLevelOutputDir, Subdirectory, DataFile, ReturnValue,
+                    TopLevelInputDir,
+                    TopLevelOutputDir,
+                    Subdirectory,
+                    DataFile,
+                    ReturnValue,
                 )
             )
             with open(f"{OutputDir}/.error_{DataFile}", "w"):
@@ -1262,7 +1267,10 @@ def _Extrapolate(FiniteRadiusWaveforms, Radii, ExtrapolationOrders, Omegas=None,
             ExtrapolatedWaveforms[i_N] = scri.WaveformModes(
                 t=FiniteRadiusWaveforms[NFiniteRadii - 1].t,
                 frame=FiniteRadiusWaveforms[NFiniteRadii - 1].frame,
-                data=np.zeros((NTimes, NModes), dtype=FiniteRadiusWaveforms[NFiniteRadii - 1].data.dtype,),
+                data=np.zeros(
+                    (NTimes, NModes),
+                    dtype=FiniteRadiusWaveforms[NFiniteRadii - 1].data.dtype,
+                ),
                 history=FiniteRadiusWaveforms[NFiniteRadii - 1].history + [f"### Extrapolating with N={N}\n"],
                 version_hist=FiniteRadiusWaveforms[NFiniteRadii - 1].version_hist,
                 frameType=FiniteRadiusWaveforms[NFiniteRadii - 1].frameType,
@@ -1288,7 +1296,8 @@ def _Extrapolate(FiniteRadiusWaveforms, Radii, ExtrapolationOrders, Omegas=None,
             completed = int(LengthProgressBar * i_t / float(NTimes - 1))
             if completed > last_completed or i_t == 0:
                 print(
-                    "[{}{}]".format("#" * completed, "-" * (LengthProgressBar - completed)), end="\r",
+                    "[{}{}]".format("#" * completed, "-" * (LengthProgressBar - completed)),
+                    end="\r",
                 )
                 stdout.flush()
                 last_completed = completed

--- a/scri/mode_calculations.py
+++ b/scri/mode_calculations.py
@@ -476,7 +476,7 @@ def corotating_frame(W, R0=quaternion.one, tolerance=1e-12, z_alignment_region=N
         R = frame[i1:i2]
         i1m = max(0, i1 - 10)
         i1p = i1m + 21
-        RoughDirection = omega[i1m+10]
+        RoughDirection = omega[i1m + 10]
         Vhat = W[i1:i2].LLDominantEigenvector(RoughDirection=RoughDirection, RoughDirectionIndex=0)
         Vhat_corot = np.array([(Ri.conjugate() * quaternion.quaternion(*Vhati) * Ri).vec for Ri, Vhati in zip(R, Vhat)])
         Vhat_corot_mean = quaternion.quaternion(*np.mean(Vhat_corot, axis=0)).normalized()

--- a/scri/modes_time_series.py
+++ b/scri/modes_time_series.py
@@ -156,7 +156,7 @@ class ModesTimeSeries(spherical_functions.Modes):
         working_ell_max: int, optional
             The value of ell_max to be used to define the computation grid. The
             number of theta points and the number of phi points are set to
-            2*working_ell_max+1. Defaults to 2*self.ell_max.
+            2*working_ell_max+1. Defaults to (self.ell_max + mts.ell_max).
         output_ell_max: int, optional
             The value of ell_max in the output mts object. Defaults to self.ell_max.
 
@@ -169,8 +169,8 @@ class ModesTimeSeries(spherical_functions.Modes):
         working_ell_max = kwargs.pop("working_ell_max", self.ell_max + mts.ell_max)
         n_theta = n_phi = 2 * working_ell_max + 1
 
-        if (self.t == mts.t).all():
-            n_times = self.n_times
+        if self.n_times != mts.n_times or not np.equal(self.t, mts.t).all():
+            raise ValueError("The time series of objects to be multiplied must be the same.")
 
         # Transform to grid representation
         self_grid = spinsfast.salm2map(
@@ -184,7 +184,7 @@ class ModesTimeSeries(spherical_functions.Modes):
         product_spin_weight = self.spin_weight + mts.spin_weight
 
         # Transform back to mode representation
-        product = spinsfast.map2salm(product_grid, product_spin_weight, lmax=working_ell_max - 1)
+        product = spinsfast.map2salm(product_grid, product_spin_weight, lmax=working_ell_max)
 
         # Convert product ndarray to a ModesTimeSeries object
         product = product[:, : LM_index(output_ell_max, output_ell_max, 0) + 1]

--- a/scri/modes_time_series.py
+++ b/scri/modes_time_series.py
@@ -60,6 +60,10 @@ class ModesTimeSeries(spherical_functions.Modes):
         self._metadata["time"][:] = new_time
         return self.time
 
+    @property
+    def n_times(self):
+        return self.time.size
+
     u = time
 
     t = time
@@ -119,6 +123,10 @@ class ModesTimeSeries(spherical_functions.Modes):
     def iint(self):
         """Integrate modes twice with respect to time"""
         return self.antiderivative(2)
+
+    @property
+    def LM(self):
+        return np.array([[ell, m] for ell in range(self.ell_min, self.ell_max + 1) for m in range(-ell, ell + 1)])
 
     @property
     def eth_GHP(self):

--- a/scri/utilities.py
+++ b/scri/utilities.py
@@ -161,7 +161,7 @@ def bump_function(x, x0, x1, x2, x3, y0=0.0, y12=1.0, y3=0.0):
 
 def transition_to_constant(f, t, t1, t2):
     """Smoothly transition from the function to a constant.
-    
+
     This works (implicitly) by multiplying the derivative of `f` with the transition function, and
     then integrating.  Using integration by parts, this simplifies to multiplying `f` itself by the
     transition function, and then subtracting the integral of `f` times the derivative of the

--- a/scri/waveform_base.py
+++ b/scri/waveform_base.py
@@ -15,6 +15,7 @@ import scipy.constants as spc
 from scipy.interpolate import CubicSpline
 from . import *
 
+
 @jit("void(c16[:,:], f8[:])")
 def complex_array_norm(c, s):
     for i in range(len(s)):
@@ -22,6 +23,7 @@ def complex_array_norm(c, s):
         for j in range(c.shape[1]):
             s[i] += c[i, j].real ** 2 + c[i, j].imag ** 2
     return
+
 
 @jit("void(c16[:,:], f8[:])")
 def complex_array_abs(c, s):
@@ -577,7 +579,7 @@ class WaveformBase(_object):
 
         This function simply subtracts the data in this waveform from the data
         in Waveform A, and finds the rotation needed to take this frame into frame A.
-        Note that the waveform data are stored as complex numbers, rather than as 
+        Note that the waveform data are stored as complex numbers, rather than as
         modulus and phase.
         """
         from quaternion.means import mean_rotor_in_chordal_metric

--- a/scri/waveform_grid.py
+++ b/scri/waveform_grid.py
@@ -343,8 +343,8 @@ class WaveformGrid(WaveformBase):
           3. Boost
         All input parameters refer to the transformation required to take the mode's inertial frame onto the inertial
         frame of the grid's inertial observers.  In what follows, the inertial frame of the modes will be unprimed,
-        while the inertial frame of the grid will be primed.  NOTE: These are passive transformations, e.g. supplying 
-        the option space_translation=[0, 0, 5] to a Schwarzschild spacetime will move the coordinates to z'=z+5 and so 
+        while the inertial frame of the grid will be primed.  NOTE: These are passive transformations, e.g. supplying
+        the option space_translation=[0, 0, 5] to a Schwarzschild spacetime will move the coordinates to z'=z+5 and so
         the center of mass will be shifted in the negative z direction by 5 in the new coordinates.
 
         The translations (space, time, spacetime, or super) can be given in various ways, which may override each
@@ -396,11 +396,11 @@ class WaveformGrid(WaveformBase):
         psi3_modes : WaveformModes, required only if w_modes is type psi2, psi1, or psi0
         psi2_modes : WaveformModes, required only if w_modes is type psi1 or psi0
         psi1_modes : WaveformModes, required only if w_modes is type psi0
-            The objects storing the modes of the original waveforms of the same spacetime that 
-            w_modes belongs to. A BMS transformation of an asymptotic Weyl scalar requires mode 
-            information from all higher index Weyl scalars. E.g. if w_modes is of type scri.psi2, 
-            then psi4_modes and psi3_modes will be required. Note: the WaveformModes objects 
-            supplied to these arguments will themselves NOT be transformed. Please use the 
+            The objects storing the modes of the original waveforms of the same spacetime that
+            w_modes belongs to. A BMS transformation of an asymptotic Weyl scalar requires mode
+            information from all higher index Weyl scalars. E.g. if w_modes is of type scri.psi2,
+            then psi4_modes and psi3_modes will be required. Note: the WaveformModes objects
+            supplied to these arguments will themselves NOT be transformed. Please use the
             AsymptoticBondiData class to efficiently transform all asymptotic data at once.
 
         Returns

--- a/scri/waveform_modes.py
+++ b/scri/waveform_modes.py
@@ -435,16 +435,12 @@ class WaveformModes(WaveformBase):
 
     @property
     def eth(self):
-        """Returns the spin-raised waveform mode data.
-
-        """
+        """Returns the spin-raised waveform mode data."""
         return self.apply_eth(operations="+")
 
     @property
     def ethbar(self):
-        """Returns the spin-lowered waveform mode data.
-
-        """
+        """Returns the spin-lowered waveform mode data."""
         return self.apply_eth(operations="-")
 
     def inner_product(self, b, t1=None, t2=None, allow_LM_differ=False, allow_times_differ=False):

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,14 @@ if __name__ == "__main__":
         url="https://github.com/moble/scri",
         author="Michael Boyle",
         author_email="mob22@cornell.edu",
-        packages=["scri", "scri.asymptotic_bondi_data", "scri.LVC", "scri.pn", "scri.SpEC", "scri.SpEC.file_io",],
+        packages=[
+            "scri",
+            "scri.asymptotic_bondi_data",
+            "scri.LVC",
+            "scri.pn",
+            "scri.SpEC",
+            "scri.SpEC.file_io",
+        ],
         zip_safe=False,
         install_requires=[
             "numpy>=1.13",

--- a/tests/test_SpEC.py
+++ b/tests/test_SpEC.py
@@ -19,7 +19,9 @@ def tempdir(tmp_path_factory):
     tmpdir = tmp_path_factory.mktemp("test_extrapolation")
     filename = tmpdir / "rh_FiniteRadii_CodeUnits.h5"
     scri.sample_waveforms.create_fake_finite_radius_strain_h5file(
-        output_file_path=filename, ell_max=3, t_1=2000.0,
+        output_file_path=filename,
+        ell_max=3,
+        t_1=2000.0,
     )
     return tmpdir
 

--- a/tests/test_abd_ivp.py
+++ b/tests/test_abd_ivp.py
@@ -54,9 +54,9 @@ def test0():
 
 def test1():
     """Add ℓ=0 term to ψ₂ intial value
-    
+
     Ensures that first terms of ψ̇₁u = ðψ₂ + 2σψ₃ and ψ̇₀ = ðψ₁ + 3σψ₂ don't get excited
-    
+
     """
 
     def modifier(sigma, sigmadot, sigmaddot, psi2, psi1, psi0):
@@ -84,9 +84,9 @@ def test1():
 
 def test2():
     """Add ℓ=1 term to ψ₂ intial value
-    
+
     Checks first term of ψ̇₁ = ðψ₂ + 2σψ₃
-    
+
     """
 
     def modifier(sigma, sigmadot, sigmaddot, psi2, psi1, psi0):
@@ -114,9 +114,9 @@ def test2():
 
 def test3():
     """Add ℓ=2 term to ψ₂ intial value
-    
+
     Checks first term of ψ̇₀ = ðψ₁ + 3σψ₂
-    
+
     """
 
     def modifier(sigma, sigmadot, sigmaddot, psi2, psi1, psi0):
@@ -146,14 +146,14 @@ def test3():
 
 def test4():
     """Add nonzero constant term to σ
-    
+
     Checks first term of ψ̇₁ = ðψ₂ + 2σψ₃ and second term of ψ̇₀ = ðψ₁ + 3σψ₂
-    
+
     After satisfaction of the reality condition on the mass aspect, ψ₂ has nonzero modes in
     {(0, 0), (2, -2), (2, 2)}, so ψ₁ should have nonzero modes in {(2, -2), (2, 2)}.  Here,
     σ has only the nonzero mode (2, 2).  Thus the product σψ₂ should result in nonzero
     modes in {(2, -2), (2, 0), (2, 2), (3, 0), (4, 0), (4, 4)}.
-    
+
     """
 
     def modifier(sigma, sigmadot, sigmaddot, psi2, psi1, psi0):

--- a/tests/test_asymptoticbondidata.py
+++ b/tests/test_asymptoticbondidata.py
@@ -129,7 +129,12 @@ def test_abd_schwarzschild_transform():
 
 def test_abd_bondi_angular_momentum():
     tolerance = 1e-14
-    for v in [np.array([0.1, 0.0, 0.0]), np.array([0.0, 0.1, 0.0]), np.array([0.1, 0.1, 0.1]), np.array([0.0, 0.0, 0.1])]:
+    for v in [
+        np.array([0.1, 0.0, 0.0]),
+        np.array([0.0, 0.1, 0.0]),
+        np.array([0.1, 0.1, 0.1]),
+        np.array([0.0, 0.0, 0.1]),
+    ]:
         mass = 1.0
         spin = 0.456
         ell_max = 8

--- a/tests/test_asymptoticbondidata.py
+++ b/tests/test_asymptoticbondidata.py
@@ -29,7 +29,7 @@ def test_abd_schwarzschild():
     psi2, psi1, psi0 = kerr_schild(mass, 0.0, ell_max)
     abd = ABD.from_initial_values(u, ell_max=ell_max, psi2=psi2)
     expected_four_momentum = np.array([mass, 0, 0, 0])
-    computed_four_momentum = abd.bondi_four_momentum
+    computed_four_momentum = abd.bondi_four_momentum()
     # print()
     # print(f"Expected four-momentum: {expected_four_momentum}")
     # print(f"Computed four-momentum: {computed_four_momentum}")
@@ -111,7 +111,7 @@ def test_abd_schwarzschild_transform():
         β = np.linalg.norm(v)
         γ = 1 / np.sqrt(1 - β ** 2)
         abdprime = abd.transform(boost_velocity=v)
-        transformed_four_momentum = abdprime.bondi_four_momentum
+        transformed_four_momentum = abdprime.bondi_four_momentum()
         expected_four_momentum = mass * γ * np.array([1,] + v.tolist())
         # print()
         # print(f"v={v}, β={β}, γ={γ}, βγ={β*γ}")

--- a/tests/test_asymptoticbondidata.py
+++ b/tests/test_asymptoticbondidata.py
@@ -15,9 +15,10 @@ def kerr_schild(mass, spin, ell_max=8):
     psi1 = np.zeros(sf.LM_total_size(0, ell_max), dtype=complex)
     psi0 = np.zeros(sf.LM_total_size(0, ell_max), dtype=complex)
 
+    # In the Moreschi-Boyle convention
     psi2[0] = -sf.constant_as_ell_0_mode(mass)
-    psi1[2] = (3j * spin / 2) * (np.sqrt((8 / 3) * np.pi))
-    psi0[6] = (3 * spin ** 2 / mass / 2) * (np.sqrt((32 / 15) * np.pi))
+    psi1[2] = -np.sqrt(2) * (3j * spin / 2) * (np.sqrt((8 / 3) * np.pi))
+    psi0[6] = 2 * (3 * spin ** 2 / mass / 2) * (np.sqrt((32 / 15) * np.pi))
 
     return psi2, psi1, psi0
 
@@ -112,7 +113,7 @@ def test_abd_schwarzschild_transform():
         γ = 1 / np.sqrt(1 - β ** 2)
         abdprime = abd.transform(boost_velocity=v)
         transformed_four_momentum = abdprime.bondi_four_momentum()
-        expected_four_momentum = mass * γ * np.array([1,] + v.tolist())
+        expected_four_momentum = mass * γ * np.array([1, *-v])
         # print()
         # print(f"v={v}, β={β}, γ={γ}, βγ={β*γ}")
         # print(f"Expected four-momentum:\n{expected_four_momentum}")

--- a/tests/test_asymptoticbondidata.py
+++ b/tests/test_asymptoticbondidata.py
@@ -163,8 +163,6 @@ def test_abd_kerr():
     tolerance = 1e-14
     # This is true beacuse we are in the center of momentum frame
     assert np.allclose(S * mass ** 2, angular_momentum, atol=tolerance, rtol=tolerance)
-    β = np.linalg.norm(v)
-    γ = 1 / np.sqrt(1 - β ** 2)
     abdprime = abd.transform(boost_velocity=v)
     S_prime = abdprime.bondi_dimensionless_spin()
     tolerance = 1e-14

--- a/tests/test_asymptoticbondidata.py
+++ b/tests/test_asymptoticbondidata.py
@@ -168,6 +168,6 @@ def test_abd_kerr():
     tolerance = 1e-14
     assert np.allclose(S_prime[-1], S[-1], atol=tolerance, rtol=tolerance)
     N = abdprime.bondi_boost_charge()
-    G = abdprime.bondi_comoving_CoM_charge()
+    G = abdprime.bondi_CoM_charge()
     P = abdprime.bondi_four_momentum()
     assert np.allclose(N, G - abdprime.t[:, np.newaxis] * P[:, 1:], atol=tolerance, rtol=tolerance)

--- a/tests/test_waveform_grid.py
+++ b/tests/test_waveform_grid.py
@@ -53,7 +53,8 @@ def test_space_translation():
                         auxiliary_waveforms[f"psi{4-i}_modes"] = samples.single_mode_proportional_to_time(s=i - 2)
                         auxiliary_waveforms[f"psi{4-i}_modes"].data *= 0
                     w_m1 = samples.single_mode_proportional_to_time(s=s, ell=ell, m=m).transform(
-                        space_translation=space_translation, **auxiliary_waveforms,
+                        space_translation=space_translation,
+                        **auxiliary_waveforms,
                     )
                     w_m2 = samples.single_mode_proportional_to_time_supertranslated(
                         s=s, ell=ell, m=m, space_translation=np.array(space_translation)
@@ -118,7 +119,8 @@ def test_hyper_translation():
                         auxiliary_waveforms[f"psi{4-i}_modes"] = samples.single_mode_proportional_to_time(s=i - 2)
                         auxiliary_waveforms[f"psi{4-i}_modes"].data *= 0
                     w_m1 = samples.single_mode_proportional_to_time(s=s, ell=ell, m=m).transform(
-                        supertranslation=supertranslation, **auxiliary_waveforms,
+                        supertranslation=supertranslation,
+                        **auxiliary_waveforms,
                     )
                     w_m2 = samples.single_mode_proportional_to_time_supertranslated(
                         s=s, ell=ell, m=m, supertranslation=supertranslation


### PR DESCRIPTION
This PR has many feature updates to the AsymptoticBondiData (ABD) class:
- Adds a function to easily create an ABD from H5 files.
- Adds the following BMS charges to ABD:
  - Bondi rest mass
  - Angular momentum
  - dimensionless spin
  - boost charge
  - comoving center-of-mass charge
  - supermomentum
- Tests have been added for each BMS charge
- Adds `ABD.copy()` and `ABD.interpolate(new_times)`
- Adds frame infrastructure to ABD to prepare for a future PR in which rotations will be added to ABD.
- Adds `grid_multiply` to ModesTimeSeries for faster products between MTS objects. This is implemented in `ABD.supermomentum` to speed up the function.
- Overall formatting & cleanup has been done.