### PR TITLE
Add tutorials to ReadTheDocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ If changes need to be made to the requirements or anything else in `recipe/meta.
 
 ## Documentation
 
-Automatically-generated API documentation is available on [Read the Docs: scri](https://scri.readthedocs.io/).
+Tutorials and automatically-generated API documentation are available on [Read the Docs: scri](https://scri.readthedocs.io/).
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ If changes need to be made to the requirements or anything else in `recipe/meta.
 
 ## Documentation
 
-Tutorials and automatically-generated API documentation are available on [Read the Docs: scri](https://scri.readthedocs.io/).
+Tutorials and automatically generated API documentation are available on [Read the Docs: scri](https://scri.readthedocs.io/).
 
 ## Acknowledgments
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,9 @@ For a quick start, take a look at the `quick start section <README.html#quick-st
    :caption: Contents:
 
    README.md
+   tutorial_abd
+   tutorial_waveformmodes
+   tutorial_extrapolation
    api
 
 Indices and tables

--- a/docs/tutorial_abd.rst
+++ b/docs/tutorial_abd.rst
@@ -98,7 +98,7 @@ other catalog using the same file format:
 The first argument specifies three different ways that the HDF5 files can be
 internally structured. We currently support ``SXS`` for extrapolated asymptotic
 files in the the SXS catalog, ``CCE`` for asymptotic files produced by
-`SpECTRE CCE <https://spectre-code.org/index.html>`_, and ``RPXM`` for compressed
+`SpECTRE CCE <https://spectre-code.org/index.html>`_, and ``RPXMB`` for compressed
 waveform files. See the documentation for :meth:`scri.SpEC.file_io.create_abd_from_h5`
 for more information about these formats. This loader will convert the data into
 the Moreschi-Boyle convention and set :math:`\sigma = \bar{h}` for ``abd.sigma``.

--- a/docs/tutorial_abd.rst
+++ b/docs/tutorial_abd.rst
@@ -1,0 +1,274 @@
+*****************************
+Tutorial: AsymptoticBondiData
+*****************************
+
+The :meth:`scri.asymptotic_bondi_data.AsymptoticBondiData` class (or ABD for short)
+is a convenient way to store and work with the standard set of asymptotic waveform
+quantities: the five Weyl scalars :math:`(\Psi_4, \Psi_3, \Psi_2, \Psi_1, \Psi_0)`
+and the Newman-Penrose shear :math:`\sigma`. These waveform quantities can be
+expanded in a spin-weighted spherical harmonic (SWSH) basis, and the coefficients of
+each mode will be stored in the ABD object.
+
+The ABD class makes it simple to compute BMS charges and fluxes, and it serves as
+a vehicle for elaborate calculations invovling asymptotic data. See the class
+documentation for more details on all it has to offer. This tutorial is by no
+means an exhaustive overview of the class.
+
+======================================
+Creating an AsymptoticBondiData Object
+======================================
+
+To create an ABD object, we first need to define the time series that all the
+waveform quantities share, the highest value of :math:`\ell` in the SWSH expansion,
+and how we will treat values of :math:`\ell` larger than ``ell_max`` during
+operations:
+
+.. testsetup::
+
+  import numpy as np
+  import scri
+
+.. doctest::
+
+  >>> abd = scri.asymptotic_bondi_data.AsymptoticBondiData(
+  ...     time = np.linspace(0,10,11),
+  ...     ell_max = 8,
+  ...     multiplication_truncator = max,
+  ... )
+
+When multiplying two fields, the SWSH expansion of the product will require a higher
+``ell_max``. Setting ``multiplication_truncator=sum`` will choose the ``ell_max`` of
+the product of two fields to be the ``sum`` of ``ell_max`` for each field. Here we
+defined each waveform quantity in ``abd`` to have ``ell_max=8``, which means that
+the product :math:`\sigma\Psi_4` will be represented by ``ell_max = 16``. This means
+that the total modes stored for ``ell_max = 16`` is 289 modes, as opposed to 81 modes
+for ``ell_max = 8``. Although it is more correct to keep all these modes, given the
+precision of numerical relativity (NR) waveforms it is often sufficient to set
+``multiplication_truncator=max`` as we have done here. This will instead choose the
+``ell_max`` of the product of the two fields to be the ``max`` of the values of
+``ell_max`` for each field. In this case, the product :math:`\sigma\Psi_4` will
+be represented by ``ell_max=8``.
+
+Now that ``abd`` is set up, we can proceed to add some asymptotic data to it. The
+data should be a ``numpy.ndarray`` of shape ``(n_times, (ell_max + 1)**2)`` , where
+``n_times`` is the size of the time array passed into the definition of ``abd`` above.
+This array must contain the coefficients of the SWSH modes starting from :math:`\ell=0`,
+even these modes are all zeros. The :math:`(\ell,m)` modes must also be in the following order:
+
+(0,0), (1,-1), (1,0), (1,1), (2,-2), (2,1), (2,0),...
+
+If we have an array ``psi4_mode_data`` of coefficients
+for :math:`\Psi_4`, then we can load this into ``abd`` by:
+
+.. testsetup::
+
+  psi4_mode_data = np.zeros((11,81))
+
+.. doctest::
+
+  >>> abd.psi4 = psi4_mode_data
+
+You can load the data for ``abd.sigma``, ``abd.psi3``, ``abd.psi2``, ``abd.psi1``,
+and ``abd.psi0`` in the same way. There are two crucial points to note for numerical
+relativists. First, the ABD class uses the Moreschi-Boyle convention, which is *not*
+the standard convention used in NR. See Appendices B and C of
+`arXiv:2010.15200 <https://arxiv.org/abs/2010.15200>`_ for more information. Second,
+the Newman-Penrose shear :math:`\sigma` is *not* the gravitational-wave strain :math:`h`.
+In the Moreschi-Boyle convention, we have the relation :math:`h = \bar{\sigma}`, but
+this relation is not gauranteed in every convention and only holds for asymptotic
+quantities.
+
+To make the ABD interface more nicely with NR waveforms, there is a tool for directly
+creating an ABD object from the HDF5 files of the
+`SXS waveform catalog <https://data.black-holes.org/waveforms/index.html>`_ or any
+other catalog using the same file format:
+
+.. code-block:: python
+
+  >>> abd = scri.SpEC.create_abd_from_h5(
+  ...     "SXS",
+  ...     h    = "/path/to/rhOverM_file.h5",
+  ...     Psi4 = "/path/to/rMPsi4_file.h5",
+  ...     Psi3 = "/path/to/r2Psi3_file.h5",
+  ...     Psi2 = "/path/to/r3Psi2OverM_file.h5",
+  ...     Psi1 = "/path/to/r4Psi1OverM2_file.h5",
+  ...     Psi0 = "/path/to/r5Psi0OverM3_file.h5",
+  ... )
+
+The first argument specifies three different ways that the HDF5 files can be
+internally structured. We currently support ``SXS`` for extrapolated asymptotic
+files in the the SXS catalog, ``CCE`` for asymptotic files produced by
+`SpECTRE CCE <https://spectre-code.org/index.html>`_, and ``RPXM`` for compressed
+waveform files. See the documentation for :meth:`scri.SpEC.file_io.create_abd_from_h5`
+for more information about these formats. This loader will convert the data into
+the Moreschi-Boyle convention and set :math:`\sigma = \bar{h}` for ``abd.sigma``.
+
+=================================
+Calculations with ModesTimeSeries
+=================================
+
+With a fully loaded ABD in hand, let's do some computations!
+The time array can be accessed by:
+
+.. code-block:: python
+
+  >>> abd.t   # or abd.u
+
+and the data for any individual quantity can be accessed by:
+
+.. code-block:: python
+
+  >>> abd.sigma
+  >>> abd.psi4
+  >>> abd.psi3
+  >>> abd.psi2
+  >>> abd.psi1
+  >>> abd.psi0
+
+Individual modes of ``abd.psi4`` (for example) can be accessed by the ``abd.psi4.index``
+function. Alternatively, you can use the ``spherical_functions.LM_index`` function from
+the `spherical_functions <https://github.com/moble/spherical_functions>`_ module. This
+can be aliased to ``lm`` for convenience, as done below. The third argument
+of ``LM_index`` is ``ell_min``, but we always have ``ell_min=0`` for ABD.
+
+.. code-block:: python
+
+  >>> # Get the (2,1) mode of Psi4
+  >>> l, m = 2, 1
+  >>> abd.psi4[:, abd.psi4.index(l,m)]
+
+  >>> # Alternatively:
+  >>> from spherical_functions import LM_index as lm
+  >>> abd.psi4[:, lm(l,m,0)]
+
+The data for each quantity is stored as a :meth:`scri.modes_time_series.ModesTimeSeries`:
+
+.. doctest::
+
+  >>> type(abd.sigma)
+  <class 'scri.modes_time_series.ModesTimeSeries'>
+
+There are many built-in functions that can be performed with a ``ModesTimeSeries``, and
+multiple operations can be composed easily. Multiple operations will be performed in order
+from left to right.
+
+.. code-block:: python
+
+  >>> # take a derivative or two
+  >>> psi4_dot  = abd.psi4.dot
+  >>> psi4_ddot = abd.psi4.ddot
+
+  >>> # Integrate once or twice
+  >>> psi4_int  = abd.psi4.int
+  >>> psi4_iint = abd.psi4.iint
+
+  >>> # Apply the eth or ethbar operator (using the GHP definition,
+  >>> # which is the one that is natural to the Moreschi-Boyle convention)
+  >>> eth_psi4    = abd.psi4.eth_GHP
+  >>> ethbar_psi4 = abd.psi4.ethbar_GHP
+
+  >>> # If you really want to use the Newman-Penrose eth operators then you can do:
+  >>> eth_psi4    = abd.psi4.eth
+  >>> ethbar_psi4 = abd.psi4.ethbar
+
+  >>> # Get fancy and combine them together
+  >>> abd.sigma.dot.eth_GHP.eth_GHP
+
+These operations will respect and update the spin-weight accordingly:
+
+.. doctest::
+
+  >>> # Check the spin-weight
+  >>> abd.sigma.s
+  2
+  >>> abd.sigma.bar.s
+  -2
+  >>> abd.sigma.dot.eth_GHP.eth_GHP.s
+  4
+
+We can add ABD quantities together, but only in a way that makes sense. An error will
+be thrown for adding quantities of different spin weights:
+
+.. code-block:: python
+
+  >>> # This will throw an error
+  >>> abd.psi4 + abd.psi3
+
+  >>> # This will work!
+  >>> abd.psi4.eth_GHP + abd.psi3
+
+There are two ways to perform multiplication with ``ModesTimeSeries`` quantities. Here
+we do not mean multiplying the mode coefficients together, but properly multiplying the
+fields and return the mode coefficients of the product. The more straightforward way
+to perform a multiplication is:
+
+.. code-block:: python
+
+  >>> sigma_psi4 = abd.sigma * abd.psi4
+
+This will combine the mode coefficients with Wigner-3j symbols to compute the resulting
+mode coefficients of the product. The benefits of this approach are that it is
+straightforward to code and it does not suffer from aliasing effects. The downside is that
+it take a long time to run, so make sure you store the result as a variable if you will
+be using it more than once!
+
+The second way to perform a multiplication is:
+
+.. code-block:: python
+
+  >>> sigma_psi4 = abd.sigma.grid_multiply(abd.psi4)
+
+This will convert ``abd.sigma`` and ``abd.psi`` from a spectral representation to a
+physical-space representation by evaluating the fields on a grid of points on
+:math:`\mathscr{I}^+`. The mutliplication is performed pointwise and then transformed
+back to a spectral representation. This approach is much faster. However, if the value
+of ``ell_max`` is not high enough then aliasing effects might arise. See the documentation
+on :meth:`scri.modes_time_series.ModesTimeSeries.grid_multiply` for options to adjust
+``ell_max`` during the operation.
+
+This just scratches the surface of all you can do with the ABD class. See the
+documentation on :meth:`scri.asymptotic_bondi_data.AsymptoticBondiData` and
+:meth:`scri.modes_time_series.ModesTimeSeries` to explore more functions.
+
+------
+Caveat
+------
+
+When taking the real part, imaginary part, or the complex conjugate, be very careful
+to know whether you are acting on the quantity as a field or just the modes of the
+quantity. For example:
+
+.. code-block:: python
+
+  >>> # This takes the real part of the quantity Psi2, and then
+  >>> # returns the modes of Re(Psi2). The mode weights are still complex!
+  >>> abd.psi2.real
+
+  >>> # This returns the real part of the mode weights of Psi2.
+  >>> # This is an array of real numbers!
+  >>> abd.psi2.ndarray.real
+
+  >>> # This returns the modes of the complex conjugate of sigma.
+  >>> # This is usually what you want.
+  >>> abd.sigma.bar
+
+  >>> # This returns the complex conjguate of the modes of sigma.
+  >>> # This is usually NOT what you want.
+  >>> np.conjugate(abd.sigma.ndarray)
+
+===================
+BMS Transformations
+===================
+
+Boosts, spacetime translations, supertranslations, and a simple frame rotation can
+all be performed with the :meth:`scri.asymptotic_bondi_data.AsymptoticBondiData.transform`
+function. See the documentation of the function for details. All the quantities in
+the ABD object will be transformed together. The transformation is not performed
+in place, so it will return a new ABD with the transformed data:
+
+.. doctest::
+
+  >>> abd_prime = abd.transform(
+  ...     space_translation=[-1., 4., 0.2],
+  ...     boost_velocity=[0., 0., 1e-2],
+  ... )

--- a/docs/tutorial_extrapolation.rst
+++ b/docs/tutorial_extrapolation.rst
@@ -1,0 +1,99 @@
+***********************
+Tutorial: Extrapolation
+***********************
+
+In numerical relativity simulations, waveform quantities are extracted at finite
+radii in the simulation domain. These extraction radii are usually at distances
+:math:`R\lesssim \mathcal{O}(10^3 M)`. As a result, the waveforms are contaminated
+by gauge and near-field effects. One way to compute the waveform at asymptotic
+null infinity :math:`\mathscr{I}^+` is by using an extrapolation procedure in
+post-processing. Such a procedure is provided by ``scri`` through the function
+:meth:`scri.extrapolation.extrapolate`; see `arXiv:2010.15200 <https://arxiv.org/abs/2010.15200>`_
+for details.
+
+=====================================
+Extrapolating Finite-Radius Waveforms
+=====================================
+
+This function will accept an HDF5 file containing the coefficients of a waveform 
+quantity expanded in the appropriate spin-weighted spherical harmonic basis. The
+format should be that of the ``rh_FiniteRadii_CodeUnits.h5`` files in the 
+`SXS Waveform Catalog <https://data.black-holes.org/waveforms/index.html>`_, which
+will now be described in detail.
+
+The internal group structure of the HDF5 file should be as follows. The root group 
+should contain one group for each extraction radius, named ``R####.dir`` where
+``####`` is a four digit number corresponding to the extraction radius. For example,
+if an extraction radius is :math:`123\, M`, the group should be named ``R0123.dir``.
+Within each extraction radius group, there should be datasets named ``Y_l#_m#.dat``
+corresponding to each :math:`(\ell,m) = (\#,\#)` mode. For example, the modes
+:math:`(3,2)` and :math:`(4,-2)` would be named ``Y_l3_m2.dat`` and ``Y_l4_-2.dat``.
+Each dataset should be of size ``(n_times, 3)``, where ``n_times`` is the number of
+timesteps. The first column should be the simulation time, the second column should 
+be the real part of the coefficient, and the third column should be the imaginary 
+part of the coefficient. The array of times should be the same for every mode and 
+every extraction radius. Isn't this quite a waste of space? Absolutely.
+
+To extrapolate the finite radius waveform data,
+
+.. code-block:: python
+
+  >>> scri.extrapolate(
+  ...     InputDirectory = "path/to/FiniteRadii_waveform_dir",
+  ...     OutputDirectory = "path/to/output_dir",
+  ...     DataFile = "waveform_FiniteRadii_CodeUnits.h5",
+  ...     ChMass = 1.0, # or whatever the initial system (Christodoulou) mass is.
+  ...     UseStupidNRARFormat = True,
+  ...     DifferenceFiles = '',
+  ...     PlotFormat = '', 
+  ... )
+
+Despite the fact that the NRAR format for HDF5 files (described in detail above)
+is quite wasteful, it's better to output the extrapolated files in this format
+for two reasons. First, the NRAR format extrapolated files interface more widely
+with functions in ``scri``. Second, these files can be highly compressed with
+the RPXM scheme described in the next section below. The RPXM-compressed files
+are far smaller than the default scri-format extrapolated files.
+
+The last two options, ``DifferenceFiles=''`` and ``PlotFormat=''``, are set to 
+supress the output of diagnostic plots. Only do this if you have your own set
+of diagnostic tests to measure the performance of the extrapolation. If you
+wish the default diagnostic plots to be produced then leave off the last
+two options:
+
+.. code-block:: python
+
+  >>> # Outputs diagnostic plots in addition to the waveforms
+  >>> scri.extrapolate(
+  ...     InputDirectory = "path/to/FiniteRadii_waveform_dir",
+  ...     OutputDirectory = "path/to/output_dir",
+  ...     DataFile = "waveform_FiniteRadii_CodeUnits.h5",
+  ...     ChMass = 1.0, # or whatever the initial system (Christodoulou) mass is.
+  ...     UseStupidNRARFormat = True,
+  ... )
+
+For more options of extrapolation function, see the documentation for 
+:meth:`scri.extrapolation.extrapolate`.
+
+============================================
+Compressing Extrapolated Waveforms with RPXM
+============================================
+
+Extrapolated waveforms in the NRAR format (described in the previous section) use
+an extravagant amount of needless space. Instead, a highly compressed HDF5 file can 
+be produced with using ``scri.SpEC.file_io.rotating_paired_xor_multishuffle_bzip2``,
+referred to as RPXM for short. Files can be reduced by anywhere from a factor 6 
+to a factor of 10, depending on the waveform data. 
+
+This compression can be performed in ``scri``. For example, let's say we want to 
+compress an extrapolated file ``rhOverM_Extrapolated_N4.h5`` and output the 
+compressed waveform to the same directory with the name 
+``rhOverM_Extrapolated_N4_RPXM.h5``. This can be done as follows:
+
+.. code-block:: python
+  
+  >>> in_file = scri.SpEC.read_from_h5("path/to/rhOverM_Extrapolated_N4.h5")
+  >>> scri.SpEC.file_io.rotating_paired_xor_multishuffle_bzip2.save(
+  ...     in_file,
+  ...     "path/to/rhOverM_Extrapolated_N4_RPXM.h5",
+  ... ) 

--- a/docs/tutorial_extrapolation.rst
+++ b/docs/tutorial_extrapolation.rst
@@ -52,7 +52,7 @@ Despite the fact that the NRAR format for HDF5 files (described in detail above)
 is quite wasteful, it's better to output the extrapolated files in this format
 for two reasons. First, the NRAR format extrapolated files interface more widely
 with functions in ``scri``. Second, these files can be highly compressed with
-the RPXM scheme described in the next section below. The RPXM-compressed files
+the RPXMB scheme described in the next section below. The RPXMB-compressed files
 are far smaller than the default scri-format extrapolated files.
 
 The last two options, ``DifferenceFiles=''`` and ``PlotFormat=''``, are set to 
@@ -76,24 +76,24 @@ For more options of extrapolation function, see the documentation for
 :meth:`scri.extrapolation.extrapolate`.
 
 ============================================
-Compressing Extrapolated Waveforms with RPXM
+Compressing Extrapolated Waveforms with RPXMB
 ============================================
 
 Extrapolated waveforms in the NRAR format (described in the previous section) use
 an extravagant amount of needless space. Instead, a highly compressed HDF5 file can 
 be produced with using ``scri.SpEC.file_io.rotating_paired_xor_multishuffle_bzip2``,
-referred to as RPXM for short. Files can be reduced by anywhere from a factor 6 
+referred to as RPXMB for short. Files can be reduced by anywhere from a factor 6 
 to a factor of 10, depending on the waveform data. 
 
 This compression can be performed in ``scri``. For example, let's say we want to 
 compress an extrapolated file ``rhOverM_Extrapolated_N4.h5`` and output the 
 compressed waveform to the same directory with the name 
-``rhOverM_Extrapolated_N4_RPXM.h5``. This can be done as follows:
+``rhOverM_Extrapolated_N4_RPXMB.h5``. This can be done as follows:
 
 .. code-block:: python
   
   >>> in_file = scri.SpEC.read_from_h5("path/to/rhOverM_Extrapolated_N4.h5")
   >>> scri.SpEC.file_io.rotating_paired_xor_multishuffle_bzip2.save(
   ...     in_file,
-  ...     "path/to/rhOverM_Extrapolated_N4_RPXM.h5",
+  ...     "path/to/rhOverM_Extrapolated_N4_RPXMB.h5",
   ... ) 

--- a/docs/tutorial_waveformmodes.rst
+++ b/docs/tutorial_waveformmodes.rst
@@ -103,9 +103,9 @@ to load the data directly into a `WaveformModes` object:
   >>> # For waveforms extrapolated by scri:
   >>> h = scri.SpEC.read_from_h5("path/to/rhOverM_Extrapolated_N4.h5")
 
-  >>> # For RPXM-compressed waveforms:
+  >>> # For RPXMB-compressed waveforms:
   >>> h = scri.SpEC.file_io.rotating_paired_xor_multishuffle_bzip2.load(
-  ...       "path/to/rhOverM_Extrapolated_N4_RPXM.h5"
+  ...       "path/to/rhOverM_Extrapolated_N4_RPXMB.h5"
   ... )[0].to_inertial_frame()
 
 More information needs to be passed into ``read_from_h5`` when trying to load a

--- a/docs/tutorial_waveformmodes.rst
+++ b/docs/tutorial_waveformmodes.rst
@@ -1,0 +1,260 @@
+************************************
+Tutorial: WaveformModes/WaveformGrid
+************************************
+
+In addition to :meth:`scri.asymptotic_bondi_data.AsymptoticBondiData`, there are
+two classes that can be used together to work with waveform data:
+:meth:`scri.WaveformModes` and :meth:`scri.WaveformGrid`. Eventually, these will
+be deprecated by the AsymptoticBondiData class, but at the current time there are
+still several features only available to ``WaveformModes`` (``WaveformGrid``).
+A ``WaveformModes`` (``WaveformGrid``) holds the data for one waveform, and lacks
+the features for complicated expressions involving multiple waveform types. For
+tasks of that sort, ``AsymptoticBondiData`` should be used instead.
+
+There are two ways to represent waveform data. The most straightfoward way is to
+compute the values of the field on a grid of points over the sphere. The
+``WaveformGrid`` object is used for this purpose. More optimally, however, the data
+can be expanded in a basis of spin-weighted spherical harmonics (SWSHs) and the
+coefficients of each mode can be stored. The ``WaveformModes`` object is used
+to store and analyze waveform data stored as coefficients of SWSH modes.
+
+===============================
+Creating a WaveformModes Object
+===============================
+
+Let's say we have a set of SWSH coefficients representing waveform data for gravitational
+wave strain, ``my_strain_data``. Since the strain has spin-weight :math:`s=-2`, any coefficients
+for modes with :math:`\ell < |s|` will be zero. ``WaveformModes`` allows us to store the
+the data starting with :math:`\ell = 2` and ignore the lower modes that would all be zero. We
+can create such a ``WaveformModes`` object as follows:
+
+.. testsetup::
+
+  import numpy as np
+  import scri
+  my_strain_data = np.zeros((100,77), dtype=complex)
+
+.. doctest::
+
+  >>> h = scri.WaveformModes(
+  ...       dataType = scri.h,
+  ...       t = np.linspace(0, 10, 100),
+  ...       data = my_strain_data,
+  ...       ell_min = 2,
+  ...       ell_max = 8,
+  ...       frameType = scri.Inertial,
+  ...       r_is_scaled_out = True,
+  ...       m_is_scaled_out = True,
+  ... )
+
+Here we have assumed that the leading fall-off behavior of the data has been scaled
+out (i.e. ``r_is_scaled_out = True``) and that the data has been scaled by the total
+initial mass of the system (i.e. ``m_is_scaled_out = True``). See the documentation
+on :meth:`scri.WaveformModes` for complete details about each option. We have also
+set the dataType to be that of gravitational wave strain ``scri.h``. The avialable
+dataTypes are: ``scri.UnknownDataType``, ``scri.psi0``, ``scri.psi1``, ``scri.psi2``,
+``scri.psi3``, ``scri.psi4``, ``scri.h``, the time derivative of the strain
+``scri.hdot``, the Newman-Penrose shear ``scri.sigma``, and ``scri.news``.
+
+A ``WaveformGrid`` object can be created in the same way. For example, let's say we have
+an grid of 144 equidistant points on the sphere at which the strain has been evaluated,
+and we have an array ``my_strain_grid_data`` of this strain data. We can create the
+following ``WaveformGrid``:
+
+.. testsetup::
+
+  my_strain_grid_data = np.zeros((100,144), dtype=complex)
+
+.. doctest::
+
+  >>> h = scri.WaveformGrid(
+  ...       dataType = scri.h,
+  ...       t = np.linspace(0, 10, 100),
+  ...       data = my_strain_grid_data,
+  ...       n_theta = 12,
+  ...       n_phi   = 12,
+  ...       frameType = scri.Inertial,
+  ...       r_is_scaled_out = True,
+  ...       m_is_scaled_out = True,
+  ... )
+
+The points in the array correspond to the following points on the sphere:
+
+.. code-block:: python
+
+  >>> grid_points = np.array([
+  >>>     (theta, phi)
+  >>>     for theta in np.linspace(0.0, np.pi, 2*h.ell_max+1, endpoint=True)
+  >>>     for phi in np.linspace(0.0, 2*np.pi, 2*h.ell_max+1, endpoint=False)
+  >>> ])
+
+------------------------------
+Loading a WaveformModes Object
+------------------------------
+
+Depending on the format of the waveform in the HDF5 file, there are several ways
+to load the data directly into a `WaveformModes` object:
+
+.. code-block:: python
+
+  >>> # For waveforms from the SXS Catalog:
+  >>> h = scri.SpEC.read_from_h5("path/to/rhOverM_Asymptotic_GeometricUnits_CoM.h5/Extrapolated_N4.dir")
+
+  >>> # For waveforms extrapolated by scri:
+  >>> h = scri.SpEC.read_from_h5("path/to/rhOverM_Extrapolated_N4.h5")
+
+  >>> # For RPXM-compressed waveforms:
+  >>> h = scri.SpEC.file_io.rotating_paired_xor_multishuffle_bzip2.load(
+  ...       "path/to/rhOverM_Extrapolated_N4_RPXM.h5"
+  ... )[0].to_inertial_frame()
+
+More information needs to be passed into ``read_from_h5`` when trying to load a
+finite-radius file. For example, if we are loading a strain waveform with data
+beloning to extraction radius :math:`R = 123\, M`. Then we would need to do the
+following:
+
+.. code-block:: python
+
+  >>> h = scri.SpEC.read_from_h5(
+  ...       "path/to/rh_FiniteRadii_CodeUnits.h5/R0123.dir",
+  ...       dataType = scri.h,
+  ...       frameType = scri.Inertial,
+  ...       r_is_scaled_out = True,
+  ...       m_is_scaled_out = True,
+  ... )
+
+In addition to this, there are several templates for generating sample waveforms
+that can be loaded quickly and easily. See the documentation on :meth:`scri.sample_waveforms`
+for all the options available. For example, a post-Newtonian waveform can be quickly
+generated by using the :meth:`scri.sample_waveforms.fake_precessing_waveform` function:
+
+.. doctest::
+
+  >>> h = scri.sample_waveforms.fake_precessing_waveform(
+  ...       t_0 = 0.0,
+  ...       t_1 = 1000.0,
+  ...       dt  = 0.1,
+  ...       ell_max = 4,
+  ...       mass_ratio = 1.0,
+  ...       precession_opening_angle = 0.0,
+  ... )
+
+==========================
+Working with WaveformModes
+==========================
+
+If we have a ``WaveformModes`` object named ``h``, the time array of the waveform
+can be accessed by calling ``h.t`` and the data array can be accessed by calling
+``h.data``. Individual modes can be accessed by the ``h.index`` function.
+Alternatively, you can use the ``spherical_functions.LM_index`` function from the
+`spherical_functions <https://github.com/moble/spherical_functions>`_ module. This
+can be aliased to ``lm`` for convenience, as done below:
+
+.. code-block:: python
+
+  >>> # Get the (2,1) mode of h
+  >>> l, m = 2, 1
+  >>> h.data[:, h.index(l,m,h.ell_min)]
+
+  >>> # Alternatively:
+  >>> from spherical_functions import LM_index as lm
+  >>> h.data[:, lm(l,m,h.ell_min)]
+
+We can convert between ``WaveformModes`` and ``WaveformGrid``:
+
+.. code-block:: python
+
+  >>> # Convert from WaveformModes to WaveformGrid:
+  >>> h_grid = h_modes.to_grid();
+
+  >>> # Convert from WaveformGrid to WaveformModes:
+  >>> h_modes = h_grid.to_modes()
+
+  >>> # You can also reduce the number of modes when converting to WaveformModes:
+  >>> new_lmax = 5
+  >>> h_modes = h_grid.to_modes(new_lmax)
+
+There are many built-in functions that can be performed with ``WaveformModes``.
+See the documentation of :meth:`scri.WaveformModes` for the complete details, but
+to name a few of the functions:
+
+.. code-block:: python
+
+  >>> # To interpolate the data onto a new time array:
+  >>> h.interpolate(new_t)
+
+  >>> # Returns the data array with a derivative with respect to h.t
+  >>> h.data_dot
+
+  >>> # Returns the data array with a second derivative with respect to h.t
+  >>> h.data_ddot
+
+  >>> # Returns the data array with an anti-derivative with respect to h.t
+  >>> h.data_int
+
+  >>> # Returns the data array with a second anti-derivative with respect to h.t
+  >>> h.data_iint
+
+  >>> # For a WaveformModes object of data type scri.h ONLY, we can
+  >>> # compute the following fluxes:
+  >>> h.energy_flux
+  >>> h.angular_momentum_flux
+  >>> h.momentum_flux
+
+  >>> # To apply a series of eth and/or ethbar derivatives:
+  >>> h.apply_eth('++--', eth_convention='GHP')
+
+See the documentation on :meth:`scri.WaveformModes.apply_eth` for details on
+applying the :math:`\eth` and :math:`\bar{\eth}` operators.
+
+===================
+BMS Transformations
+===================
+
+Boosts, spacetime translations, supertranslations, and a simple frame rotation can
+all be performed with the :meth:`scri.WaveformModes.transform` function.
+function. See the documentation of that function (and the underlying function
+:meth:`scri.WaveformGrid.from_modes`) for details. The transformation is not performed
+in place, so it will return a new object with the transformed data:
+
+.. doctest::
+
+  >>> h_prime = h.transform(
+  ...     space_translation=[-1., 4., 0.2],
+  ...     boost_velocity=[0., 0., 1e-2],
+  ... )
+
+The ABD class also supports more advanced frame rotations that interfaces with the
+`quaternion <https://github.com/moble/quaternion>`_ python module. Given a unit
+quaternion ``R`` or an array of unit quaterions ``R``, you can perform a rotation
+of the data:
+
+.. testsetup::
+
+  import quaternion
+  R = quaternion.one
+
+.. doctest::
+
+  >>> rotated_h = h.rotate_decomposition_basis(R)
+
+  >>> # Also:
+  >>> rotated_h = h.rotate_physical_system(R)
+
+This will return the rotated quantity, which will also store the rotor or array
+of rotors that made the transformation.
+
+There are functions to go to the corotating or coprecessing frame too. At any
+point you can undo all the frame rotations by going back to the inertial frame:
+
+.. code-block:: python
+
+  >>> h.to_corotating_frame()
+  >>> h.to_coprecessing_frame()
+  >>> h.to_inertial_frame()
+
+The quaternion or array of quaternions that define the frame can be accessed by:
+
+.. code-block:: python
+
+  >>> h.frame

--- a/scri/SpEC/com_motion.py
+++ b/scri/SpEC/com_motion.py
@@ -302,9 +302,9 @@ def remove_avg_com_motion(
         If None and there is no Matter.h5 file, the mass will be read from
         Horizons.h5; otherwise, the mass will be read from the metadata
         `reference_mass2`.
-    file_format: 'NRAR' or 'RPXM' [default is 'NRAR']
+    file_format: 'NRAR' or 'RPXMB' [default is 'NRAR']
         The file format of the waveform data H5 file. The 'NRAR' format is the
-        default file format found in the SXS Catalog. The 'RPXM' format is data
+        default file format found in the SXS Catalog. The 'RPXMB' format is data
         compressed with the rotating_paired_xor_multishuffle_bzip2 scheme.
 
     Returns
@@ -326,10 +326,10 @@ def remove_avg_com_motion(
     # Read the waveform data in
     if file_format.lower() == "nrar":
         w_m = read_from_h5(path_to_waveform_h5)
-    elif file_format.lower() == "rpxm":
+    elif file_format.lower() == "rpxmb" or file_format.lower() == "rpxm":
         w_m = rotating_paired_xor_multishuffle_bzip2.load(path_to_waveform_h5)[0].to_inertial_frame()
     else:
-        raise ValueError(f"File format {file_format} not recognized. Must be either 'NRAR' or 'RPXM'.")
+        raise ValueError(f"File format {file_format} not recognized. Must be either 'NRAR' or 'RPXMB'.")
 
     if path_to_horizons_h5 is None:
         path_to_horizons_h5 = os.path.join(directory, "Horizons.h5")
@@ -402,7 +402,7 @@ def remove_avg_com_motion(
             try:
                 if file_format.lower() == "nrar":
                     aux_waveforms[f"psi{4-i}_modes"] = read_from_h5(aux_path)
-                elif file_format.lower() == "rpxm":
+                elif file_format.lower() == "rpxmb" or file_format.lower() == "rpxm":
                     aux_waveforms[f"psi{4-i}_modes"] = rotating_paired_xor_multishuffle_bzip2.load(aux_path)[0]
                     aux_waveforms[f"psi{4-i}_modes"].to_inertial_frame()
             except (FileNotFoundError, OSError):
@@ -428,7 +428,7 @@ def remove_avg_com_motion(
             file_write_mode=file_write_mode,
             attributes={"space_translation": x_0, "boost_velocity": v_0},
         )
-    elif file_format.lower() == "rpxm":
+    elif file_format.lower() == "rpxmb" or file_format.lower() == "rpxm":
         path_to_new_waveform_h5 = path_to_waveform_h5.replace(".h5", "_CoM.h5", 1)
         w_m.boost_velocity = v_0
         w_m.space_translation = x_0

--- a/scri/SpEC/file_io/__init__.py
+++ b/scri/SpEC/file_io/__init__.py
@@ -414,11 +414,11 @@ def create_abd_from_h5(file_format, convention="SpEC", **kwargs):
 
     Parameters
     ----------
-    file_format : 'SXS', 'CCE', or 'RPXM'
+    file_format : 'SXS', 'CCE', or 'RPXMB'
         The H5 files may be in the one of the following file formats:
           * 'SXS'  - Dimensionless extrapolated waveform files found in the SXS Catalog, also known as NRAR format.
           * 'CCE'  - Asymptotic waveforms output by SpECTRE CCE. These are not dimensionless.
-          * 'RPXM' - Dimensionless waveforms compressed using the rotating_paired_xor_multishuffle_bzip2 format.
+          * 'RPXMB' - Dimensionless waveforms compressed using the rotating_paired_xor_multishuffle_bzip2 format.
     convention : 'SpEC' or 'Moreschi-Boyle'
         The data conventions of the waveform data that will be loaded. This defaults to 'SpEC' since this will be
         most often used with 'SpEC' convention waveforms.
@@ -461,11 +461,11 @@ def create_abd_from_h5(file_format, convention="SpEC", **kwargs):
                     r_is_scaled_out=True,
                     m_is_scaled_out=False,
                 )
-            elif file_format == "rpxm":
+            elif file_format == "rpxmb" or file_format == "rpxm":
                 WMs[data_label] = rotating_paired_xor_multishuffle_bzip2.load(filenames[data_label])[0]
                 WMs[data_label].to_inertial_frame()
             else:
-                raise ValueError(f"File format '{file_format}' not recognized. Must be either 'SXS', 'CCE', or 'RPXM'.")
+                raise ValueError(f"File format '{file_format}' not recognized. Must be either 'SXS', 'CCE', or 'RPXMB'.")
 
     if kwargs:
         import pprint


### PR DESCRIPTION
This adds three tutorials to ReadTheDocs:

- Using the `AsymptoticBondiData` class
- Using the `WaveformModes`/`WaveformGrid` class
- Performing extrapolation

These tutorials are not exhaustive but provide enough information to get a new user started. 