### PR TITLE
Explain that waveforms use references to original data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,5 +71,7 @@ tmp
 build_artifacts
 # conda smithy ci-skeleton end
 
+# vim
+*.swp
 
 .envrc

--- a/scri/waveform_modes.py
+++ b/scri/waveform_modes.py
@@ -36,6 +36,8 @@ class WaveformModes(WaveformBase):
         Mode values of the spin-weighted spherical-harmonic decomposition. The array is assumed to have a first
         dimension equal to the length of `t`, and a second dimension equal to the number of modes as deduced from the
         values of ell_min and ell_max below.  As noted above, a very particular order is assumed for the data.
+        Input is treated as a reference, so in-place transformations may modify your original array. To avoid this
+        behavior, pass a copy of your array.
     ell_min : int
         Smallest ell value present in `data`.
     ell_max : int


### PR DESCRIPTION
The input data array can get manipulated internally by `WaveformModes`.    
This is now mentioned in the documentation.
Also, gotta have .swp in .gitignore.