### PR TITLE
Bugfix in removing non-monotonic time steps before extrapolating.

### DIFF
--- a/scri/extrapolation.py
+++ b/scri/extrapolation.py
@@ -356,12 +356,15 @@ def read_finite_radius_waveform(filename, groupname, WaveformName, ChMass):
     else:
         raise ValueError(f'DataType "{waveform.dataType}" is unknown.')
 
+    # The read_finite_radius_waveform_* functions removed nonmonotonic times
+    # from T but did not do the same for the waveform data. So we do that here.
+    waveform.data = waveform.data[Indices,:]
+
     # Rescale the times and the data
     RadiusRatio = (Radii / CoordRadius) ** RadiusRatioExp
     waveform.t = T/ChMass
     for m,_ in enumerate(waveform.LM):
-        waveform.data[:,m] = \
-            waveform.data[Indices,m] * RadiusRatio * UnitScaleFactor
+        waveform.data[:,m] *= RadiusRatio * UnitScaleFactor
     waveform.m_is_scaled_out = True
 
     # Add the history information

--- a/scri/extrapolation.py
+++ b/scri/extrapolation.py
@@ -360,6 +360,11 @@ def read_finite_radius_waveform(filename, groupname, WaveformName, ChMass):
     # from T but did not do the same for the waveform data. So we do that here.
     waveform.data = waveform.data[Indices,:]
 
+    # We also need to remove nonmonontonic times from the frame, if the
+    # frame has the appropriate shape.
+    if waveform.frame.shape[0] > 1:
+        waveform.frame = waveform.frame[Indices]
+
     # Rescale the times and the data
     RadiusRatio = (Radii / CoordRadius) ** RadiusRatioExp
     waveform.t = T/ChMass


### PR DESCRIPTION
In extrapolation.py, read_finite_radius_waveform checks for non-monotonic timesteps in the input finite-radius data, and removes these non-monotonic timesteps.  Unfortunately:
1) It removes the timesteps correctly from the time array, but removes them incorrectly for the waveform data, causing a "cannot broadcast input array from shape BLA1 into shape BLA2" error whenever it actually removes non-monotonic timesteps.
2) It neglects to remove those same non-monotonic timesteps from the frame data, leading to similar shape-mismatch errors down the line.

This PR fixes both the above bugs.