### PR TITLE
Enabling python 11 and updated versions of tqdm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["Michael Boyle <michael.oliver.boyle@gmail.com>"]
 homepage = "https://github.com/moble/scri"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.11"
+python = ">=3.8,<3.12"
 numpy = ">=1.20"
 scipy = "^1.0"
 numba = ">=0.55"
@@ -17,7 +17,7 @@ numpy-quaternion = ">=2022.4"
 spherical-functions = ">=2022.4"
 spinsfast = ">=2022.4"
 sxs = ">=2022.4.0"
-tqdm = ">=4.48.2, <4.61.2"
+tqdm = ">=4.48.2"
 importlib-metadata = {version = "^1.0", python = "<3.8"}
 mkdocs = {version = "^1.1.2", optional = true}
 mktheapidocs = {extras = ["plugin"], version = "^0.2.0", optional = true}
@@ -35,7 +35,7 @@ mktheapidocs = ["mktheapidocs"]
 
 [tool.black]
 line-length = 120
-target-version = ['py38','py39','py310']
+target-version = ['py38','py39','py310','py311']
 
 [tool.pytest.ini_options]
 minversion = "6.0"


### PR DESCRIPTION
This is a very basic PR

* bumping the allowed version of python to include python 11
* removing the upper version bound of tqdm to allow installation of eg. pandas 2

I am not very familiar with `poetry` but I am able to run this branch as part of a pip requirement file without issues.