### PR TITLE
Update ``create_abd_from_h5`` to include other post-processing options; update documentation

### DIFF
--- a/docs/tutorial_abd.rst
+++ b/docs/tutorial_abd.rst
@@ -74,7 +74,7 @@ relativists. First, the ABD class uses the Moreschi-Boyle convention, which is *
 the standard convention used in NR. See Appendices B and C of
 `arXiv:2010.15200 <https://arxiv.org/abs/2010.15200>`_ for more information. Second,
 the Newman-Penrose shear :math:`\sigma` is *not* the gravitational-wave strain :math:`h`.
-In the Moreschi-Boyle convention, we have the relation :math:`h = \bar{\sigma}`, but
+In the Moreschi-Boyle convention, we have the relation :math:`h = 2\bar{\sigma}`, but
 this relation is not gauranteed in every convention and only holds for asymptotic
 quantities.
 
@@ -282,16 +282,16 @@ composing BMS transformations. For more, see :ref:`bms_transformations`.
 BMS Frames
 ==========
 
-All waveforms at future null infinity (and all waveforms more generally) are functions or coordinates.
+All waveforms at future null infinity (and all waveforms more generally) are functions of coordinates.
 Therefore, there are certain "frames" which may be more useful than others, like that of a rest frame.
-For waveforms at future null infinity, the number of coordinates freedoms, i.e., the symmetries, that they
+For waveforms at future null infinity, the number of coordinate freedoms, i.e., the symmetries, that they
 exhibit is infinite and is summarized by a group known as the BMS group. This controls the types of frames
 that one may map waveforms to. Because GR is covariant, there is no preferred frame. However, for performing
 analysis on waveforms or building waveform models, it turns out that there are certain frames that are
 more useful than others. In particular, within GR one can extend the notion of a rest frame to something called
 a "superrest frame" (see arXiv:2405.08868 or arXiv:2208.04356 for more details), which typically yields waveforms
 that are easier to understand/analyze. Effectively, mapping to this frame amounts to mapping the system to be
-in the center-of-mass frame, with no instananeous memory, and it's angular velocity in the z-direction. For example,
+in the center-of-mass frame, with no instananeous memory, and its angular velocity in the z-direction. For example,
 for a remnant black hole, this corresponds to making the coordinates match those of the usual Kerr metric and is
 therefore incredibly useful (and necessary) for fitting QNMs to NR waveforms.
 
@@ -325,13 +325,13 @@ It also can perform a number of other important post-processing steps, such as:
 * interpolate to a coarser time array, such as the time array of the worldtube. This is performed via the ``t_interpolate`` option.
 
 * map to the superrest BMS frame at some time. This is performed via the ``t_0_superrest`` and ``padding_time`` options.
-  E.g., to make reasonable-looking waveforms, one should map to the superrest frame at some time after junk;
+  E.g., to make reasonable-looking waveforms, one should map to the superrest frame at some time after junk radiation;
   ``t_0_superrest`` is the time at which to map to this frame, and ``padding_time`` is the window around ``t_0_superrest``
   that is used when computing this BMS transformation. ``t_0_superrest - padding_time`` should be after junk radiation.
-  ``padding_time`` should be a few hundred :math:`h=2\overline{\sigma}`, e.g., two orbital periods.
+  ``padding_time`` should be a few hundred :math:`h=2\overline{\sigma}` (where :math:`\sigma` is the shear), e.g., two orbital periods.
   The function used to do this is ``abd.map_to_superrest_frame`` (see the "BMS Frames" section).
 
-We recommend including all of these post-processing steps when processing a SpECTRE CCE output.
+We recommend including all of these post-processing steps when processing SpECTRE CCE output.
 
 To obtain the strain :math:`h` from the ``abd`` object, one can use the function ``scri.asymptotic_bondi_data.map_to_superrest_frame.MT_to_WM`` via ``h = MT_to_WM(2.0*abd.sigma.bar)``. 
 This is because the strain :math:`h` is related to the shear :math:`\sigma` via :math:`h=2\overline{\sigma}`.
@@ -341,6 +341,7 @@ Example usage of this function could be:
 .. code-block:: python
 
   >>> import scri
+  >>> import matplotlib.pyplot as plt
   >>> abd = scri.SpEC.file_io.create_abd_from_h5(
         file_name='CharacteristicExtractVolume_R0292.h5',
         file_format="spectrecce",
@@ -349,4 +350,8 @@ Example usage of this function could be:
         t_0_superrest=1600,
         padding_time=200
       )
-  >>> h = scri.asymptotic_bondi_data.map_to_superrest_frame.MT_to_WM(2.0*abd.sigma.bar)
+  >>> h = abd.h
+  >>> plt.plot(h.t, h.data[:, h.index(2,2)])
+  >>> plt.show()
+
+For more on the :meth:`scri.WaveformModes` class, i.e., what :math:`h` is in the above code, see https://github.com/moble/scri/blob/main/docs/tutorial_waveformmodes.rst.

--- a/docs/tutorial_abd.rst
+++ b/docs/tutorial_abd.rst
@@ -277,3 +277,76 @@ These components of a BMS transformation can also all be stored in the
 :meth:`scri.bms_transformations.BMSTransformation` class, which allows for things like
 reording the components of the BMS transformation, inverting BMS transformations, and
 composing BMS transformations. For more, see :ref:`bms_transformations`. 
+
+==========
+BMS Frames
+==========
+
+All waveforms at future null infinity (and all waveforms more generally) are functions or coordinates.
+Therefore, there are certain "frames" which may be more useful than others, like that of a rest frame.
+For waveforms at future null infinity, the number of coordinates freedoms, i.e., the symmetries, that they
+exhibit is infinite and is summarized by a group known as the BMS group. This controls the types of frames
+that one may map waveforms to. Because GR is covariant, there is no preferred frame. However, for performing
+analysis on waveforms or building waveform models, it turns out that there are certain frames that are
+more useful than others. In particular, within GR one can extend the notion of a rest frame to something called
+a "superrest frame" (see arXiv:2405.08868 or arXiv:2208.04356 for more details), which typically yields waveforms
+that are easier to understand/analyze. Effectively, mapping to this frame amounts to mapping the system to be
+in the center-of-mass frame, with no instananeous memory, and it's angular velocity in the z-direction. For example,
+for a remnant black hole, this corresponds to making the coordinates match those of the usual Kerr metric and is
+therefore incredibly useful (and necessary) for fitting QNMs to NR waveforms.
+
+The function ``scri.asymptotic_bondi_data.map_to_superrest_frame`` maps to this exact frame.
+In particular, it takes as input:
+
+* ``t_0``, the time at which to map to the superrest frame;
+
+* ``target_PsiM_input``, the target Moreschi supermomentum; this should be ``None`` to map to the superrest frame,
+  but to map to the PN BMS frame one should input the PN Moreschi supermomentum (see arXiv:2208.04356).
+
+* ``target_strain_input``, the target strain; this should be ``None`` to map to the superrest frame,
+  but to map to the PN BMS frame one should input the PN strain (see arXiv:2208.04356).
+
+* ``padding_time``, the time window about ``t_0`` to be used when finding the BMS transformation to the superrest frame.
+
+========================================================
+Creating an AsymptoticBondiData Object from a CCE Output
+========================================================
+
+For processing the output of SpECTRE CCE, one may use the function ``scri.SpEC.file_io.create_abd_from_h5``.
+This function takes as input the path to SpECTRE CCE's output file (via the option ``file_name``) and
+creates an ``abd`` object from said file.
+It also can perform a number of other important post-processing steps, such as:
+
+* time translate the time array of the waveforms by the radius of the worldtube; this ensures that the CCE waveforms
+  are more closely aligned (in time) with extrapolated waveform. This is performed via the ``radius`` option.
+
+* scale out the total Christoudoulou mass of the system from each waveform. This is performed via the ``ch_mass`` option.
+
+* interpolate to a coarser time array, such as the time array of the worldtube. This is performed via the ``t_interpolate`` option.
+
+* map to the superrest BMS frame at some time. This is performed via the ``t_0_superrest`` and ``padding_time`` options.
+  E.g., to make reasonable-looking waveforms, one should map to the superrest frame at some time after junk;
+  ``t_0_superrest`` is the time at which to map to this frame, and ``padding_time`` is the window around ``t_0_superrest``
+  that is used when computing this BMS transformation. ``t_0_superrest - padding_time`` should be after junk radiation.
+  ``padding_time`` should be a few hundred :math:`h=2\overline{\sigma}`, e.g., two orbital periods.
+  The function used to do this is ``abd.map_to_superrest_frame`` (see the "BMS Frames" section).
+
+We recommend including all of these post-processing steps when processing a SpECTRE CCE output.
+
+To obtain the strain :math:`h` from the ``abd`` object, one can use the function ``scri.asymptotic_bondi_data.map_to_superrest_frame.MT_to_WM`` via ``h = MT_to_WM(2.0*abd.sigma.bar)``. 
+This is because the strain :math:`h` is related to the shear :math:`\sigma` via :math:`h=2\overline{\sigma}`.
+
+Example usage of this function could be:
+
+.. code-block:: python
+
+  >>> import scri
+  >>> abd = scri.SpEC.file_io.create_abd_from_h5(
+        file_name='CharacteristicExtractVolume_R0292.h5',
+        file_format="spectrecce",
+        ch_mass=1.0,
+        t_interpolate=t_worldtube,
+        t_0_superrest=1600,
+        padding_time=200
+      )
+  >>> h = scri.asymptotic_bondi_data.map_to_superrest_frame.MT_to_WM(2.0*abd.sigma.bar)

--- a/scri/SpEC/file_io/__init__.py
+++ b/scri/SpEC/file_io/__init__.py
@@ -468,6 +468,8 @@ def create_abd_from_h5(
 
     Parameters
     ----------
+    file_name : str,
+        Path to .h5 file to be loaded.
     file_format : 'SXS', 'SpECTRECCE', 'RPDMB', or 'RPXMB'
         The H5 files may be in the one of the following file formats:
           * 'SXS'  - Dimensionless extrapolated waveform files found in the SXS Catalog, also known as NRAR format.

--- a/scri/SpEC/file_io/__init__.py
+++ b/scri/SpEC/file_io/__init__.py
@@ -468,10 +468,10 @@ def create_abd_from_h5(
 
     Parameters
     ----------
-    file_format : 'SXS', 'SpECTRECCE', 'RPDMB', or 'RPXMB'
+    file_format : 'SXS', 'SpECTRECCE_v1', 'RPDMB', or 'RPXMB'
         The H5 files may be in the one of the following file formats:
           * 'SXS'  - Dimensionless extrapolated waveform files found in the SXS Catalog, also known as NRAR format.
-          * 'SpECTRECCE' - Asymptotic waveforms output by SpECTRE CCE.
+          * 'SpECTRECCE_v1' - Asymptotic waveforms output by SpECTRE CCE v1.
           * 'RPDMB' - Dimensionless waveforms compressed using the rotating_paired_diff_multishuffle_bzip2 format.
           * 'RPXMB' - Dimensionless waveforms compressed using the rotating_paired_xor_multishuffle_bzip2 format.
     convention : 'SpEC' or 'Moreschi-Boyle'
@@ -508,11 +508,6 @@ def create_abd_from_h5(
 
     """
 
-    try:
-        file_name = kwargs.pop("file_name")
-    except:
-        raise ValueError('Need to specify "file_name" option!')
-
     # Use case insensitive parameters
     file_format = file_format.lower()
     convention = convention.lower()
@@ -520,7 +515,12 @@ def create_abd_from_h5(
     # Load waveform data from H5 files into WaveformModes objects
     WMs = {}
     filenames = {}
-    if file_format == "spectrecce":
+    if file_format == "spectrecce_v1":
+        try:
+            file_name = kwargs.pop("file_name")
+        except:
+            raise ValueError('Need to specify "file_name" option!')
+
         with h5py.File(file_name, "r") as f:
             for x in f.keys():
                 if "Spectre" in x:
@@ -575,7 +575,7 @@ def create_abd_from_h5(
                 else:
                     raise ValueError(
                         f"File format '{file_format}' not recognized. "
-                        "Must be 'SXS', 'CCE', 'SpECTRECCE', 'RPDMB', or 'RPXMB'."
+                        "Must be 'SXS', 'CCE', 'SpECTRECCE_v1', 'RPDMB', or 'RPXMB'."
                     )
 
     if kwargs:
@@ -601,7 +601,7 @@ def create_abd_from_h5(
             make_variable_dimensionless(WMs[i], ch_mass)
 
         # Adjust time by worldtube radius
-        if file_format == "spectrecce":
+        if file_format == "spectrecce_v1":
             WMs[i].t -= float(radius)
 
     # Create an instance of AsymptoticBondiData

--- a/scri/__init__.py
+++ b/scri/__init__.py
@@ -159,6 +159,7 @@ from .asymptotic_bondi_data import AsymptoticBondiData
 
 from . import sample_waveforms, SpEC, LVC, utilities
 from .SpEC import rpxmb
+from .SpEC.file_io import create_abd_from_h5
 
 from .bms_transformations import LorentzTransformation, BMSTransformation
 

--- a/scri/asymptotic_bondi_data/__init__.py
+++ b/scri/asymptotic_bondi_data/__init__.py
@@ -1,5 +1,6 @@
 import numpy as np
 from spherical_functions import LM_total_size
+from .. import WaveformModes
 from .. import ModesTimeSeries
 from .. import Inertial
 
@@ -113,6 +114,20 @@ class AsymptoticBondiData:
     def sigma(self, sigmaprm):
         self._sigma[:] = sigmaprm
         return self.sigma
+
+    @property
+    def h(self):
+        h_mts = 2.0 * self._sigma.bar
+        return WaveformModes(
+            t=h_mts.t,
+            data=np.array(h_mts)[:, h_mts.index(abs(h_mts.s), -abs(h_mts.s)) :],
+            ell_min=abs(h_mts.s),
+            ell_max=h_mts.ell_max,
+            frameType=Inertial,
+            dataType=7,
+            r_is_scaled_out=True,
+            m_is_scaled_out=True,
+        )
 
     @property
     def psi4(self):

--- a/scri/asymptotic_bondi_data/__init__.py
+++ b/scri/asymptotic_bondi_data/__init__.py
@@ -3,6 +3,7 @@ from spherical_functions import LM_total_size
 from .. import WaveformModes
 from .. import ModesTimeSeries
 from .. import Inertial
+from .. import h as h_DataType
 
 
 class AsymptoticBondiData:
@@ -124,7 +125,7 @@ class AsymptoticBondiData:
             ell_min=abs(h_mts.s),
             ell_max=h_mts.ell_max,
             frameType=Inertial,
-            dataType=7,
+            dataType=h_DataType,
             r_is_scaled_out=True,
             m_is_scaled_out=True,
         )


### PR DESCRIPTION
Update the ``create_abd_from_h5`` function to include other post-processing, i.e., time translate by the worldtube radius, scale out the total Christodoulou mass to make waveforms dimensionless, interpolate on to some coarser time array, and map to some reasonable BMS frame. Documentation in docs/tutorial_abd.rst has also been updated.