### PR TITLE
Add 2nd monotonic requirement; fixes subtle bug affecting some CCE outputs

### DIFF
--- a/scri/SpEC/file_io/__init__.py
+++ b/scri/SpEC/file_io/__init__.py
@@ -604,10 +604,14 @@ def create_abd_from_h5(
         if file_format == "spectrecce_v1":
             WMs[i].t -= float(radius)
 
+        indices = index_is_monotonic(WMs[i].t)
+        WMs[i].t = WMs[i].t[indices]
+        WMs[i].data = WMs[i].data[indices]
+            
     # Create an instance of AsymptoticBondiData
     abd = AsymptoticBondiData(
-        time=WM_ref.t,
-        ell_max=WM_ref.ell_max,
+        time=WMs[list(WMs.keys())[0]].t,
+        ell_max=WMs[list(WMs.keys())[0]].ell_max,
         multiplication_truncator=max,
     )
 

--- a/scri/SpEC/file_io/__init__.py
+++ b/scri/SpEC/file_io/__init__.py
@@ -610,8 +610,8 @@ def create_abd_from_h5(
             
     # Create an instance of AsymptoticBondiData
     abd = AsymptoticBondiData(
-        time=WMs[list(WMs.keys())[0]].t,
-        ell_max=WMs[list(WMs.keys())[0]].ell_max,
+        time=WM_ref.t,
+        ell_max=WM_ref.ell_max,
         multiplication_truncator=max,
     )
 

--- a/scri/utilities.py
+++ b/scri/utilities.py
@@ -372,7 +372,7 @@ def multishuffle(shuffle_widths, forward=True):
                     b_array_bit += shuffle_width
             return b
 
-        return nb.jit(shuffle)
+        return nb.njit(shuffle)
 
     else:
         # This function is almost the same as above, except for:
@@ -404,4 +404,4 @@ def multishuffle(shuffle_widths, forward=True):
                     b_array_bit += shuffle_width
             return a
 
-        return nb.jit(unshuffle)
+        return nb.njit(unshuffle)

--- a/tests/test_waveform_grid.py
+++ b/tests/test_waveform_grid.py
@@ -159,6 +159,7 @@ def test_hyper_translation():
 
 
 def test_supertranslation_inverses():
+    np.random.seed(1234)
     w1 = samples.random_waveform_proportional_to_time(rotating=False)
     ell_max = 4
     for ellpp, mpp in sf.LM_range(0, ell_max):


### PR DESCRIPTION
@moble should be an easy review; fixes a bug that occurs when the output CCE data has time steps with differences ~1e-15, which are set to zero when doing `-= float(radius)` and screw up the monotonicity of the time array.