### PR TITLE
extrapolation: Print the error for the mode data validation

### DIFF
--- a/scri/extrapolation.py
+++ b/scri/extrapolation.py
@@ -169,7 +169,7 @@ def validate_single_waveform(h5file, filename, WaveformName, ExpectedNModes, Exp
         if CompiledModeRegex.search(dataset):
             if not h5file[WaveformName + "/" + dataset].shape == (ExpectedNTimes, 3):
                 Valid = False
-                (
+                print(
                     "{}:{}/{}\n\tGot shape {}; expected ({}, 3)".format(
                         filename,
                         WaveformName,


### PR DESCRIPTION
As simple as that, there was a missing print statement for this validation case.