### PR TITLE
Update RTD conf: now need a sphinx.configuration key [skip ci]

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,5 +13,9 @@ python:
     - method: pip
       path: .
 
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
 # Don't build any extra formats
 formats: []


### PR DESCRIPTION
RTD has changed the requirements of their .readthedocs.yaml files. Either sphinx.configuration or mkdocs.configuration is mandatory.